### PR TITLE
[Feature] 게시물 좋아요, 관심없음에 이벤트를 적용한다

### DIFF
--- a/src/main/java/daybyquest/global/config/AsyncConfig.java
+++ b/src/main/java/daybyquest/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package daybyquest.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/daybyquest/global/event/Event.java
+++ b/src/main/java/daybyquest/global/event/Event.java
@@ -1,0 +1,5 @@
+package daybyquest.global.event;
+
+public interface Event {
+
+}

--- a/src/main/java/daybyquest/like/application/SavePostDislikeService.java
+++ b/src/main/java/daybyquest/like/application/SavePostDislikeService.java
@@ -1,7 +1,9 @@
 package daybyquest.like.application;
 
 import daybyquest.like.domain.PostDislike;
+import daybyquest.like.domain.PostDislikedEvent;
 import daybyquest.like.domain.PostDislikes;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,13 +12,18 @@ public class SavePostDislikeService {
 
     private final PostDislikes postDislikes;
 
-    public SavePostDislikeService(final PostDislikes postDislikes) {
+    private final ApplicationEventPublisher publisher;
+
+    public SavePostDislikeService(final PostDislikes postDislikes,
+            final ApplicationEventPublisher publisher) {
         this.postDislikes = postDislikes;
+        this.publisher = publisher;
     }
 
     @Transactional
     public void invoke(final Long loginId, final Long postId) {
         final PostDislike postDislike = new PostDislike(postId, loginId);
         postDislikes.save(postDislike);
+        publisher.publishEvent(new PostDislikedEvent(loginId, postId));
     }
 }

--- a/src/main/java/daybyquest/like/application/SavePostLikeService.java
+++ b/src/main/java/daybyquest/like/application/SavePostLikeService.java
@@ -1,7 +1,9 @@
 package daybyquest.like.application;
 
 import daybyquest.like.domain.PostLike;
+import daybyquest.like.domain.PostLikedEvent;
 import daybyquest.like.domain.PostLikes;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,13 +12,17 @@ public class SavePostLikeService {
 
     private final PostLikes postLikes;
 
-    public SavePostLikeService(final PostLikes postLikes) {
+    private final ApplicationEventPublisher publisher;
+
+    public SavePostLikeService(final PostLikes postLikes, final ApplicationEventPublisher publisher) {
         this.postLikes = postLikes;
+        this.publisher = publisher;
     }
 
     @Transactional
     public void invoke(final Long loginId, final Long postId) {
         final PostLike postLike = new PostLike(postId, loginId);
         postLikes.save(postLike);
+        publisher.publishEvent(new PostLikedEvent(loginId, postId));
     }
 }

--- a/src/main/java/daybyquest/like/domain/PostDislikedEvent.java
+++ b/src/main/java/daybyquest/like/domain/PostDislikedEvent.java
@@ -1,0 +1,17 @@
+package daybyquest.like.domain;
+
+import daybyquest.global.event.Event;
+import lombok.Getter;
+
+@Getter
+public class PostDislikedEvent implements Event {
+
+    private final Long userId;
+
+    private final Long postId;
+
+    public PostDislikedEvent(final Long userId, final Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/daybyquest/like/domain/PostDislikes.java
+++ b/src/main/java/daybyquest/like/domain/PostDislikes.java
@@ -35,6 +35,10 @@ public class PostDislikes {
         postDislikeRepository.deleteByUserIdAndPostId(userId, postId);
     }
 
+    public void deleteByUserIdAndPostIdWithoutValidation(final Long userId, final Long postId) {
+        postDislikeRepository.deleteByUserIdAndPostId(userId, postId);
+    }
+
     private void validateNotExistent(final Long userId, final Long postId) {
         if (postDislikeRepository.existsByUserIdAndPostId(userId, postId)) {
             throw new InvalidDomainException(ALREADY_DISLIKED_POST);

--- a/src/main/java/daybyquest/like/domain/PostLikedEvent.java
+++ b/src/main/java/daybyquest/like/domain/PostLikedEvent.java
@@ -1,0 +1,17 @@
+package daybyquest.like.domain;
+
+import daybyquest.global.event.Event;
+import lombok.Getter;
+
+@Getter
+public class PostLikedEvent implements Event {
+
+    private final Long userId;
+
+    private final Long postId;
+
+    public PostLikedEvent(final Long userId, final Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/daybyquest/like/domain/PostLikes.java
+++ b/src/main/java/daybyquest/like/domain/PostLikes.java
@@ -35,6 +35,10 @@ public class PostLikes {
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);
     }
 
+    public void deleteByUserIdAndPostIdWithoutValidation(final Long userId, final Long postId) {
+        postLikeRepository.deleteByUserIdAndPostId(userId, postId);
+    }
+
     private void validateNotExistent(final Long userId, final Long postId) {
         if (postLikeRepository.existsByUserIdAndPostId(userId, postId)) {
             throw new InvalidDomainException(ALREADY_LIKED_POST);

--- a/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
@@ -1,9 +1,13 @@
 package daybyquest.like.listener;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
 import daybyquest.like.application.DeletePostDislikeService;
 import daybyquest.like.domain.PostLikedEvent;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 public class DeletePostDislikeListener {
@@ -14,7 +18,9 @@ public class DeletePostDislikeListener {
         this.deletePostDislikeService = deletePostDislikeService;
     }
 
-    @EventListener
+    @Async
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener(fallbackExecution = true)
     public void listenPostLikedEvent(final PostLikedEvent event) {
         deletePostDislikeService.invoke(event.getUserId(), event.getPostId());
     }

--- a/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
@@ -2,7 +2,7 @@ package daybyquest.like.listener;
 
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
-import daybyquest.like.application.DeletePostDislikeService;
+import daybyquest.like.domain.PostDislikes;
 import daybyquest.like.domain.PostLikedEvent;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -12,16 +12,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class DeletePostDislikeListener {
 
-    private final DeletePostDislikeService deletePostDislikeService;
+    private final PostDislikes postDislikes;
 
-    public DeletePostDislikeListener(final DeletePostDislikeService deletePostDislikeService) {
-        this.deletePostDislikeService = deletePostDislikeService;
+    public DeletePostDislikeListener(final PostDislikes postDislikes) {
+        this.postDislikes = postDislikes;
     }
 
     @Async
     @Transactional(propagation = REQUIRES_NEW)
     @TransactionalEventListener(fallbackExecution = true)
     public void listenPostLikedEvent(final PostLikedEvent event) {
-        deletePostDislikeService.invoke(event.getUserId(), event.getPostId());
+        postDislikes.deleteByUserIdAndPostIdWithoutValidation(event.getUserId(), event.getPostId());
     }
 }

--- a/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostDislikeListener.java
@@ -1,0 +1,21 @@
+package daybyquest.like.listener;
+
+import daybyquest.like.application.DeletePostDislikeService;
+import daybyquest.like.domain.PostLikedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeletePostDislikeListener {
+
+    private final DeletePostDislikeService deletePostDislikeService;
+
+    public DeletePostDislikeListener(final DeletePostDislikeService deletePostDislikeService) {
+        this.deletePostDislikeService = deletePostDislikeService;
+    }
+
+    @EventListener
+    public void listenPostLikedEvent(final PostLikedEvent event) {
+        deletePostDislikeService.invoke(event.getUserId(), event.getPostId());
+    }
+}

--- a/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
@@ -1,9 +1,13 @@
 package daybyquest.like.listener;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
 import daybyquest.like.application.DeletePostLikeService;
 import daybyquest.like.domain.PostDislikedEvent;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 public class DeletePostLikeListener {
@@ -14,7 +18,9 @@ public class DeletePostLikeListener {
         this.deletePostLikeService = deletePostLikeService;
     }
 
-    @EventListener
+    @Async
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener(fallbackExecution = true)
     public void listenPostDislikedEvent(final PostDislikedEvent event) {
         deletePostLikeService.invoke(event.getUserId(), event.getPostId());
     }

--- a/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
@@ -1,0 +1,21 @@
+package daybyquest.like.listener;
+
+import daybyquest.like.application.DeletePostLikeService;
+import daybyquest.like.domain.PostDislikedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeletePostLikeListener {
+
+    private final DeletePostLikeService deletePostLikeService;
+
+    public DeletePostLikeListener(final DeletePostLikeService deletePostLikeService) {
+        this.deletePostLikeService = deletePostLikeService;
+    }
+
+    @EventListener
+    public void listenPostDislikedEvent(final PostDislikedEvent event) {
+        deletePostLikeService.invoke(event.getUserId(), event.getPostId());
+    }
+}

--- a/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
+++ b/src/main/java/daybyquest/like/listener/DeletePostLikeListener.java
@@ -2,8 +2,8 @@ package daybyquest.like.listener;
 
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
-import daybyquest.like.application.DeletePostLikeService;
 import daybyquest.like.domain.PostDislikedEvent;
+import daybyquest.like.domain.PostLikes;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,16 +12,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class DeletePostLikeListener {
 
-    private final DeletePostLikeService deletePostLikeService;
+    private final PostLikes postLikes;
 
-    public DeletePostLikeListener(final DeletePostLikeService deletePostLikeService) {
-        this.deletePostLikeService = deletePostLikeService;
+    public DeletePostLikeListener(final PostLikes postLikes) {
+        this.postLikes = postLikes;
     }
 
     @Async
     @Transactional(propagation = REQUIRES_NEW)
     @TransactionalEventListener(fallbackExecution = true)
     public void listenPostDislikedEvent(final PostDislikedEvent event) {
-        deletePostLikeService.invoke(event.getUserId(), event.getPostId());
+        postLikes.deleteByUserIdAndPostIdWithoutValidation(event.getUserId(), event.getPostId());
     }
 }


### PR DESCRIPTION
## 🗒️ Summary
- 게시물 좋아요, 관심없음에 이벤트를 적용
  - 이제 서로 상호배재적인 관계를 가짐. (좋아요를 누를 시 관심없음이 취소된다, 역도 마찬가지)
- `Async`와 관련된 설정은 임시로 적용하였으며 스레드풀과 관련된 추가 설정이 필요하다. #40 참조

>resolve: #36, #37

## 💡 More
- 