### PR TITLE
[Test] Follows, PostLikes, PostDislikes 테스트를 작성한다

### DIFF
--- a/src/main/java/daybyquest/comment/application/SaveCommentService.java
+++ b/src/main/java/daybyquest/comment/application/SaveCommentService.java
@@ -17,7 +17,7 @@ public class SaveCommentService {
 
     @Transactional
     public void invoke(final Long loginId, final Long postId, final SaveCommentRequest request) {
-        final Comment comment = new Comment(postId, loginId, request.getContent());
+        final Comment comment = new Comment(loginId, postId, request.getContent());
         comments.save(comment);
     }
 }

--- a/src/main/java/daybyquest/comment/domain/Comment.java
+++ b/src/main/java/daybyquest/comment/domain/Comment.java
@@ -28,10 +28,10 @@ public class Comment {
     private Long id;
 
     @Column(nullable = false)
-    private Long postId;
+    private Long userId;
 
     @Column(nullable = false)
-    private Long userId;
+    private Long postId;
 
     @Column(nullable = false, length = MAX_CONTENT_SIZE)
     private String content;
@@ -39,9 +39,9 @@ public class Comment {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public Comment(Long postId, Long userId, String content) {
-        this.postId = postId;
+    public Comment(Long userId, Long postId, String content) {
         this.userId = userId;
+        this.postId = postId;
         this.content = content;
         validateContent();
     }

--- a/src/main/java/daybyquest/dislike/application/SavePostDislikeService.java
+++ b/src/main/java/daybyquest/dislike/application/SavePostDislikeService.java
@@ -22,7 +22,7 @@ public class SavePostDislikeService {
 
     @Transactional
     public void invoke(final Long loginId, final Long postId) {
-        final PostDislike postDislike = new PostDislike(postId, loginId);
+        final PostDislike postDislike = new PostDislike(loginId, postId);
         postDislikes.save(postDislike);
         publisher.publishEvent(new PostDislikedEvent(loginId, postId));
     }

--- a/src/main/java/daybyquest/dislike/domain/PostDislike.java
+++ b/src/main/java/daybyquest/dislike/domain/PostDislike.java
@@ -14,14 +14,13 @@ import lombok.NoArgsConstructor;
 public class PostDislike {
 
     @Id
-    private Long postId;
-
-    @Id
     private Long userId;
 
-    public PostDislike(Long postId, Long userId) {
-        this.postId = postId;
-        this.userId = userId;
-    }
+    @Id
+    private Long postId;
 
+    public PostDislike(Long userId, Long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
 }

--- a/src/main/java/daybyquest/dislike/domain/PostDislikeId.java
+++ b/src/main/java/daybyquest/dislike/domain/PostDislikeId.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostDislikeId implements Serializable {
 
-    private Long postId;
-
     private Long userId;
+
+    private Long postId;
 
 }

--- a/src/main/java/daybyquest/like/application/SavePostLikeService.java
+++ b/src/main/java/daybyquest/like/application/SavePostLikeService.java
@@ -21,7 +21,7 @@ public class SavePostLikeService {
 
     @Transactional
     public void invoke(final Long loginId, final Long postId) {
-        final PostLike postLike = new PostLike(postId, loginId);
+        final PostLike postLike = new PostLike(loginId, postId);
         postLikes.save(postLike);
         publisher.publishEvent(new PostLikedEvent(loginId, postId));
     }

--- a/src/main/java/daybyquest/like/domain/PostLike.java
+++ b/src/main/java/daybyquest/like/domain/PostLike.java
@@ -14,14 +14,14 @@ import lombok.NoArgsConstructor;
 public class PostLike {
 
     @Id
-    private Long postId;
-
-    @Id
     private Long userId;
 
-    public PostLike(Long postId, Long userId) {
-        this.postId = postId;
+    @Id
+    private Long postId;
+
+    public PostLike(Long userId, Long postId) {
         this.userId = userId;
+        this.postId = postId;
     }
 
 }

--- a/src/main/java/daybyquest/like/domain/PostLikeId.java
+++ b/src/main/java/daybyquest/like/domain/PostLikeId.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostLikeId implements Serializable {
 
-    private Long postId;
-
     private Long userId;
+
+    private Long postId;
 
 }

--- a/src/main/java/daybyquest/relation/domain/Follows.java
+++ b/src/main/java/daybyquest/relation/domain/Follows.java
@@ -4,6 +4,7 @@ import static daybyquest.global.error.ExceptionCode.ALREADY_FOLLOWING_USER;
 import static daybyquest.global.error.ExceptionCode.NOT_FOLLOWING_USER;
 
 import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.user.domain.Users;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,11 +12,16 @@ public class Follows {
 
     private final FollowRepository followRepository;
 
-    Follows(final FollowRepository followRepository) {
+    private final Users users;
+
+    Follows(final FollowRepository followRepository, final Users users) {
         this.followRepository = followRepository;
+        this.users = users;
     }
 
     public void save(final Follow follow) {
+        users.validateExistentById(follow.getUserId());
+        users.validateExistentById(follow.getTargetId());
         validateNonExistent(follow);
         followRepository.save(follow);
     }

--- a/src/test/java/daybyquest/comment/domain/CommentsTest.java
+++ b/src/test/java/daybyquest/comment/domain/CommentsTest.java
@@ -32,10 +32,10 @@ public class CommentsTest {
     void 사용자와_게시물_ID를_검증하고_댓글을_저장한다() {
         // given
         final Long userId = 1L;
-        final Long postId = 1L;
+        final Long postId = 2L;
 
         // when
-        comments.save(댓글_1.생성(postId, userId));
+        comments.save(댓글_1.생성(userId, postId));
 
         // then
         assertAll(() -> {

--- a/src/test/java/daybyquest/dislike/domain/PostDislikesTest.java
+++ b/src/test/java/daybyquest/dislike/domain/PostDislikesTest.java
@@ -1,0 +1,101 @@
+package daybyquest.dislike.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.post.domain.Posts;
+import daybyquest.user.domain.Users;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PostDislikesTest {
+
+    @Mock
+    private PostDislikeRepository postDislikeRepository;
+
+    @Mock
+    private Users users;
+
+    @Mock
+    private Posts posts;
+
+    @InjectMocks
+    private PostDislikes postDislikes;
+
+    @Test
+    void 사용자와_게시물_ID를_검증하고_관심없음을_저장한다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when
+        postDislikes.save(new PostDislike(userId, postId));
+
+        // then
+        assertAll(() -> {
+            verify(users).validateExistentById(userId);
+            verify(posts).validateExistentById(postId);
+            verify(postDislikeRepository).save(any(PostDislike.class));
+        });
+    }
+
+    @Test
+    void 저장_시_이미_관심없음_중이라면_예외를_던진다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+        given(postDislikeRepository.existsByUserIdAndPostId(userId, postId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> postDislikes.save(new PostDislike(userId, postId)))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 사용자와_게시물_ID를_검증하고_관심없음을_삭제한다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+        given(postDislikeRepository.existsByUserIdAndPostId(userId, postId)).willReturn(true);
+
+        // when
+        postDislikes.deleteByUserIdAndPostId(userId, postId);
+
+        // then
+        verify(postDislikeRepository).deleteByUserIdAndPostId(userId, postId);
+    }
+
+    @Test
+    void 삭제_시_관심없음이_없다면_예외를_던진다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when & then
+        assertThatThrownBy(() -> postDislikes.deleteByUserIdAndPostId(userId, postId))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 검증_없이_삭제_시_존재하지_않아도_예외를_던지지_않는다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when & then
+        assertAll(() -> {
+            assertThatCode(() -> postDislikes.deleteByUserIdAndPostIdWithoutValidation(userId, postId))
+                    .doesNotThrowAnyException();
+            verify(postDislikeRepository).deleteByUserIdAndPostId(userId, postId);
+        });
+    }
+}

--- a/src/test/java/daybyquest/like/domain/PostLikesTest.java
+++ b/src/test/java/daybyquest/like/domain/PostLikesTest.java
@@ -1,0 +1,102 @@
+package daybyquest.like.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.post.domain.Posts;
+import daybyquest.user.domain.Users;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PostLikesTest {
+
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
+
+    @Mock
+    private Users users;
+
+    @Mock
+    private Posts posts;
+
+    @InjectMocks
+    private PostLikes postLikes;
+
+    @Test
+    void 사용자와_게시물_ID를_검증하고_좋아요를_저장한다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when
+        postLikes.save(new PostLike(userId, postId));
+
+        // then
+        assertAll(() -> {
+            verify(users).validateExistentById(userId);
+            verify(posts).validateExistentById(postId);
+            verify(postLikeRepository).save(any(PostLike.class));
+        });
+    }
+
+    @Test
+    void 저장_시_이미_좋아요_중이라면_예외를_던진다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+        given(postLikeRepository.existsByUserIdAndPostId(userId, postId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> postLikes.save(new PostLike(userId, postId)))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 사용자와_게시물_ID를_검증하고_좋아요를_삭제한다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+        given(postLikeRepository.existsByUserIdAndPostId(userId, postId)).willReturn(true);
+
+        // when
+        postLikes.deleteByUserIdAndPostId(userId, postId);
+
+        // then
+        verify(postLikeRepository).deleteByUserIdAndPostId(userId, postId);
+    }
+
+    @Test
+    void 삭제_시_좋아요가_없다면_예외를_던진다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when & then
+        assertThatThrownBy(() -> postLikes.deleteByUserIdAndPostId(userId, postId))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 검증_없이_삭제_시_존재하지_않아도_예외를_던지지_않는다() {
+        // given
+        final Long userId = 1L;
+        final Long postId = 2L;
+
+        // when & then
+        assertAll(() -> {
+            assertThatCode(() -> postLikes.deleteByUserIdAndPostIdWithoutValidation(userId, postId))
+                    .doesNotThrowAnyException();
+            verify(postLikeRepository).deleteByUserIdAndPostId(userId, postId);
+        });
+    }
+}

--- a/src/test/java/daybyquest/relation/domain/FollowsTest.java
+++ b/src/test/java/daybyquest/relation/domain/FollowsTest.java
@@ -1,0 +1,99 @@
+package daybyquest.relation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.user.domain.Users;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FollowsTest {
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private Users users;
+
+    @InjectMocks
+    private Follows follows;
+
+    @Test
+    void 사용자_ID를_검증하고_팔로우를_저장한다() {
+        // given
+        final Long aliceId = 1L;
+        final Long targetId = 2L;
+
+        // when
+        follows.save(new Follow(aliceId, targetId));
+
+        // then
+        assertAll(() -> {
+            verify(users).validateExistentById(aliceId);
+            verify(users).validateExistentById(targetId);
+            verify(followRepository).save(any(Follow.class));
+        });
+    }
+
+    @Test
+    void 저장_시_이미_팔로우_중이라면_예외를_던진다() {
+        // given
+        final Long aliceId = 1L;
+        final Long targetId = 2L;
+        given(followRepository.existsByUserIdAndTargetId(aliceId, targetId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> follows.save(new Follow(aliceId, targetId)))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 사용자_ID와_대상_ID를_통해_팔로우를_조회한다() {
+        // given
+        final Long aliceId = 1L;
+        final Long targetId = 2L;
+        final Follow follow = new Follow(aliceId, targetId);
+        given(followRepository.findByUserIdAndTargetId(aliceId, targetId)).willReturn(Optional.of(follow));
+
+        // when
+        final Follow actual = follows.getByUserIdAndTargetId(aliceId, targetId);
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(follow);
+    }
+
+    @Test
+    void 사용자_ID와_대상_ID를_통한_조회_시_팔로우가_없다면_예외를_던진다() {
+        // given
+        final Long aliceId = 1L;
+        final Long targetId = 2L;
+
+        // when & then
+        assertThatThrownBy(() -> follows.getByUserIdAndTargetId(aliceId, targetId))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 팔로우를_삭제한다() {
+        // given
+        final Long aliceId = 1L;
+        final Long targetId = 2L;
+        final Follow follow = new Follow(aliceId, targetId);
+
+        // when
+        follows.delete(follow);
+
+        // then
+        verify(followRepository).delete(follow);
+    }
+}


### PR DESCRIPTION
## 🗒️ Summary
### 리팩토링
- `PostLike`, `Comment`, `PostDislike`의 필드 중 `userId`가 `postId`보다 먼저 오도록 수정
  - 기존 메서드와의 통일감을 높여 실수할 확률을 줄여줌 

>resolve: #50

## 💡 More
- 