### PR TITLE
[Feature] 퀘스트 상태 변경 기능들을 구현한다

### DIFF
--- a/src/main/java/daybyquest/auth/domain/AccessUser.java
+++ b/src/main/java/daybyquest/auth/domain/AccessUser.java
@@ -1,9 +1,10 @@
 package daybyquest.auth.domain;
 
-import daybyquest.global.error.exception.InvalidDomainException;
+import lombok.Getter;
 
 public class AccessUser {
 
+    @Getter
     private final Long id;
 
     private final Authority authority;
@@ -23,13 +24,6 @@ public class AccessUser {
 
     public static AccessUser ofAdmin(final Long id) {
         return new AccessUser(id, Authority.ADMIN);
-    }
-
-    public Long getId() {
-        if (!isUser()) {
-            throw new InvalidDomainException();
-        }
-        return id;
     }
 
     public boolean isUser() {

--- a/src/main/java/daybyquest/participant/application/ContinueQuestService.java
+++ b/src/main/java/daybyquest/participant/application/ContinueQuestService.java
@@ -1,0 +1,22 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.participant.domain.Participants;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ContinueQuestService {
+
+    private final Participants participants;
+
+    public ContinueQuestService(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId) {
+        final Participant participant = participants.getByUserIdAndQuestId(loginId, questId);
+        participant.doContinue();
+    }
+}

--- a/src/main/java/daybyquest/participant/application/DeleteParticipantService.java
+++ b/src/main/java/daybyquest/participant/application/DeleteParticipantService.java
@@ -1,0 +1,20 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.Participants;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DeleteParticipantService {
+
+    private final Participants participants;
+
+    public DeleteParticipantService(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId) {
+        participants.deleteByUserIdAndQuestId(loginId, questId);
+    }
+}

--- a/src/main/java/daybyquest/participant/application/FinishQuestService.java
+++ b/src/main/java/daybyquest/participant/application/FinishQuestService.java
@@ -1,0 +1,22 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.participant.domain.Participants;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FinishQuestService {
+
+    private final Participants participants;
+
+    public FinishQuestService(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId) {
+        final Participant participant = participants.getByUserIdAndQuestId(loginId, questId);
+        participant.finish();
+    }
+}

--- a/src/main/java/daybyquest/participant/application/SaveParticipantService.java
+++ b/src/main/java/daybyquest/participant/application/SaveParticipantService.java
@@ -1,6 +1,5 @@
 package daybyquest.participant.application;
 
-import daybyquest.participant.domain.Participant;
 import daybyquest.participant.domain.Participants;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +15,7 @@ public class SaveParticipantService {
 
     @Transactional
     public void invoke(final Long loginId, final Long questId) {
-        final Participant participant = new Participant(loginId, questId);
-        participants.save(participant);
+        participants.saveWithUserIdAndQuestId(loginId, questId);
     }
 }
 

--- a/src/main/java/daybyquest/participant/application/SaveParticipantService.java
+++ b/src/main/java/daybyquest/participant/application/SaveParticipantService.java
@@ -1,0 +1,23 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.participant.domain.Participants;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SaveParticipantService {
+
+    private final Participants participants;
+
+    public SaveParticipantService(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId) {
+        final Participant participant = new Participant(loginId, questId);
+        participants.save(participant);
+    }
+}
+

--- a/src/main/java/daybyquest/participant/application/TakeRewardService.java
+++ b/src/main/java/daybyquest/participant/application/TakeRewardService.java
@@ -1,0 +1,22 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.participant.domain.Participants;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TakeRewardService {
+
+    private final Participants participants;
+
+    public TakeRewardService(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId) {
+        final Participant participant = participants.getByUserIdAndQuestId(loginId, questId);
+        participant.takeReward();
+    }
+}

--- a/src/main/java/daybyquest/participant/domain/Participant.java
+++ b/src/main/java/daybyquest/participant/domain/Participant.java
@@ -1,11 +1,20 @@
 package daybyquest.participant.domain;
 
+import static daybyquest.global.error.ExceptionCode.NOT_FINISHABLE_QUEST;
+import static daybyquest.participant.domain.ParticipantState.CONTINUE;
+import static daybyquest.participant.domain.ParticipantState.DOING;
+import static daybyquest.participant.domain.ParticipantState.FINISHED;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.quest.domain.Quest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,15 +29,42 @@ public class Participant {
     private Long userId;
 
     @Id
-    private Long questId;
+    @ManyToOne
+    @JoinColumn(name = "quest_id")
+    private Quest quest;
 
     @Column(nullable = false, length = 10)
     @Enumerated(EnumType.STRING)
     private ParticipantState state;
 
-    public Participant(Long userId, Long questId) {
+    public Participant(Long userId, Quest quest) {
         this.userId = userId;
-        this.questId = questId;
-        this.state = ParticipantState.DOING;
+        this.quest = quest;
+        this.state = DOING;
+    }
+
+    public Long getQuestId() {
+        return quest.getId();
+    }
+
+    public void takeReward() {
+        if (state == FINISHED || state == CONTINUE) {
+            throw new InvalidDomainException(NOT_FINISHABLE_QUEST);
+        }
+        state = FINISHED;
+    }
+
+    public void finish() {
+        if (state != CONTINUE) {
+            throw new InvalidDomainException(NOT_FINISHABLE_QUEST);
+        }
+        state = FINISHED;
+    }
+
+    public void doContinue() {
+        if (state != FINISHED) {
+            throw new InvalidDomainException(NOT_FINISHABLE_QUEST);
+        }
+        state = CONTINUE;
     }
 }

--- a/src/main/java/daybyquest/participant/domain/Participant.java
+++ b/src/main/java/daybyquest/participant/domain/Participant.java
@@ -17,18 +17,18 @@ import lombok.NoArgsConstructor;
 public class Participant {
 
     @Id
-    private Long questId;
+    private Long userId;
 
     @Id
-    private Long userId;
+    private Long questId;
 
     @Column(nullable = false, length = 10)
     @Enumerated(EnumType.STRING)
     private ParticipantState state;
 
-    public Participant(Long questId, Long userId) {
-        this.questId = questId;
+    public Participant(Long userId, Long questId) {
         this.userId = userId;
+        this.questId = questId;
         this.state = ParticipantState.DOING;
     }
 }

--- a/src/main/java/daybyquest/participant/domain/ParticipantId.java
+++ b/src/main/java/daybyquest/participant/domain/ParticipantId.java
@@ -11,6 +11,6 @@ public class ParticipantId implements Serializable {
 
     private Long userId;
 
-    private Long questId;
+    private Long quest;
 
 }

--- a/src/main/java/daybyquest/participant/domain/ParticipantId.java
+++ b/src/main/java/daybyquest/participant/domain/ParticipantId.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode
 public class ParticipantId implements Serializable {
 
-    private Long questId;
-
     private Long userId;
+
+    private Long questId;
 
 }

--- a/src/main/java/daybyquest/participant/domain/ParticipantRepository.java
+++ b/src/main/java/daybyquest/participant/domain/ParticipantRepository.java
@@ -1,9 +1,15 @@
 package daybyquest.participant.domain;
 
+import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
-public interface ParticipantRepository extends Repository<Participant, ParticipantId> {
+interface ParticipantRepository extends Repository<Participant, ParticipantId> {
 
     Participant save(Participant participant);
 
+    Optional<Participant> findByUserIdAndQuestId(final Long userId, final Long questId);
+
+    boolean existsByUserIdAndQuestId(final Long userId, final Long questId);
+
+    void delete(final Participant participant);
 }

--- a/src/main/java/daybyquest/participant/domain/ParticipantRepository.java
+++ b/src/main/java/daybyquest/participant/domain/ParticipantRepository.java
@@ -1,14 +1,17 @@
 package daybyquest.participant.domain;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 interface ParticipantRepository extends Repository<Participant, ParticipantId> {
 
     Participant save(Participant participant);
 
+    @Query("SELECT p FROM Participant p WHERE p.userId=:userId and p.quest.id = :questId")
     Optional<Participant> findByUserIdAndQuestId(final Long userId, final Long questId);
 
+    @Query("SELECT count (p) > 0 FROM Participant p WHERE p.userId=:userId and p.quest.id = :questId")
     boolean existsByUserIdAndQuestId(final Long userId, final Long questId);
 
     void delete(final Participant participant);

--- a/src/main/java/daybyquest/participant/domain/Participants.java
+++ b/src/main/java/daybyquest/participant/domain/Participants.java
@@ -1,0 +1,50 @@
+package daybyquest.participant.domain;
+
+import static daybyquest.global.error.ExceptionCode.ALREADY_ACCEPTED_QUEST;
+import static daybyquest.global.error.ExceptionCode.NOT_ACCEPTED_QUEST;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.quest.domain.Quests;
+import daybyquest.user.domain.Users;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Participants {
+
+    private final ParticipantRepository participantRepository;
+
+    private final Users users;
+
+    private final Quests quests;
+
+    Participants(final ParticipantRepository participantRepository, final Users users,
+            final Quests quests) {
+        this.participantRepository = participantRepository;
+        this.users = users;
+        this.quests = quests;
+    }
+
+    public void save(final Participant participant) {
+        users.validateExistentById(participant.getUserId());
+        quests.validateExistentById(participant.getQuestId());
+        validateNotExistent(participant);
+        participantRepository.save(participant);
+    }
+
+    private void validateNotExistent(final Participant participant) {
+        if (participantRepository.existsByUserIdAndQuestId(participant.getUserId(),
+                participant.getQuestId())) {
+            throw new InvalidDomainException(ALREADY_ACCEPTED_QUEST);
+        }
+    }
+
+    public Participant getByUserIdAndQuestId(final Long userId, final Long questId) {
+        return participantRepository.findByUserIdAndQuestId(userId, questId)
+                .orElseThrow(() -> new InvalidDomainException(NOT_ACCEPTED_QUEST));
+    }
+
+    public void deleteByUserIdAndQuestId(final Long userId, final Long questId) {
+        final Participant participant = getByUserIdAndQuestId(userId, questId);
+        participantRepository.delete(participant);
+    }
+}

--- a/src/main/java/daybyquest/participant/domain/Participants.java
+++ b/src/main/java/daybyquest/participant/domain/Participants.java
@@ -4,6 +4,7 @@ import static daybyquest.global.error.ExceptionCode.ALREADY_ACCEPTED_QUEST;
 import static daybyquest.global.error.ExceptionCode.NOT_ACCEPTED_QUEST;
 
 import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
 import daybyquest.user.domain.Users;
 import org.springframework.stereotype.Component;
@@ -24,9 +25,10 @@ public class Participants {
         this.quests = quests;
     }
 
-    public void save(final Participant participant) {
-        users.validateExistentById(participant.getUserId());
-        quests.validateExistentById(participant.getQuestId());
+    public void saveWithUserIdAndQuestId(final Long userId, final Long questId) {
+        users.validateExistentById(userId);
+        final Quest quest = quests.getById(questId);
+        final Participant participant = new Participant(userId, quest);
         validateNotExistent(participant);
         participantRepository.save(participant);
     }

--- a/src/main/java/daybyquest/participant/listener/IncreaseLinkedCountListener.java
+++ b/src/main/java/daybyquest/participant/listener/IncreaseLinkedCountListener.java
@@ -1,0 +1,30 @@
+package daybyquest.participant.listener;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.participant.domain.Participants;
+import daybyquest.post.domain.SuccessfullyPostLinkedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class IncreaseLinkedCountListener {
+
+    private final Participants participants;
+
+    public IncreaseLinkedCountListener(final Participants participants) {
+        this.participants = participants;
+    }
+
+    @Async
+    @Transactional(propagation = REQUIRES_NEW)
+    @TransactionalEventListener(fallbackExecution = true)
+    public void listenSuccessfullyPostLinkedEvent(final SuccessfullyPostLinkedEvent event) {
+        final Participant participant = participants.getByUserIdAndQuestId(event.getUserId(),
+                event.getQuestId());
+        participant.increaseLinkedCount();
+    }
+}

--- a/src/main/java/daybyquest/participant/presentation/ParticipantCommandApi.java
+++ b/src/main/java/daybyquest/participant/presentation/ParticipantCommandApi.java
@@ -1,10 +1,14 @@
 package daybyquest.participant.presentation;
 
 import daybyquest.auth.domain.AccessUser;
+import daybyquest.participant.application.ContinueQuestService;
 import daybyquest.participant.application.DeleteParticipantService;
+import daybyquest.participant.application.FinishQuestService;
 import daybyquest.participant.application.SaveParticipantService;
+import daybyquest.participant.application.TakeRewardService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,10 +20,21 @@ public class ParticipantCommandApi {
 
     private final DeleteParticipantService deleteParticipantService;
 
+    private final TakeRewardService takeRewardService;
+
+    private final FinishQuestService finishQuestService;
+
+    private final ContinueQuestService continueQuestService;
+
     public ParticipantCommandApi(final SaveParticipantService saveParticipantService,
-            final DeleteParticipantService deleteParticipantService) {
+            final DeleteParticipantService deleteParticipantService,
+            final TakeRewardService takeRewardService, final FinishQuestService finishQuestService,
+            final ContinueQuestService continueQuestService) {
         this.saveParticipantService = saveParticipantService;
         this.deleteParticipantService = deleteParticipantService;
+        this.takeRewardService = takeRewardService;
+        this.finishQuestService = finishQuestService;
+        this.continueQuestService = continueQuestService;
     }
 
     @PostMapping("/quest/{questId}/accept")
@@ -33,6 +48,27 @@ public class ParticipantCommandApi {
     public ResponseEntity<Void> deleteParticipant(final AccessUser accessUser,
             @PathVariable final Long questId) {
         deleteParticipantService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/quest/{questId}/reward")
+    public ResponseEntity<Void> takeReward(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        takeRewardService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/quest/{questId}/finish")
+    public ResponseEntity<Void> finishQuest(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        finishQuestService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/quest/{questId}/continue")
+    public ResponseEntity<Void> continueQuest(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        continueQuestService.invoke(accessUser.getId(), questId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/daybyquest/participant/presentation/ParticipantCommandApi.java
+++ b/src/main/java/daybyquest/participant/presentation/ParticipantCommandApi.java
@@ -1,0 +1,38 @@
+package daybyquest.participant.presentation;
+
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.participant.application.DeleteParticipantService;
+import daybyquest.participant.application.SaveParticipantService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ParticipantCommandApi {
+
+    private final SaveParticipantService saveParticipantService;
+
+    private final DeleteParticipantService deleteParticipantService;
+
+    public ParticipantCommandApi(final SaveParticipantService saveParticipantService,
+            final DeleteParticipantService deleteParticipantService) {
+        this.saveParticipantService = saveParticipantService;
+        this.deleteParticipantService = deleteParticipantService;
+    }
+
+    @PostMapping("/quest/{questId}/accept")
+    public ResponseEntity<Void> saveParticipant(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        saveParticipantService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/quest/{questId}/accept")
+    public ResponseEntity<Void> deleteParticipant(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        deleteParticipantService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/daybyquest/post/application/JudgePostService.java
+++ b/src/main/java/daybyquest/post/application/JudgePostService.java
@@ -1,0 +1,39 @@
+package daybyquest.post.application;
+
+import daybyquest.global.error.exception.BadRequestException;
+import daybyquest.post.domain.Judgement;
+import daybyquest.post.domain.Post;
+import daybyquest.post.domain.Posts;
+import daybyquest.post.domain.SuccessfullyPostLinkedEvent;
+import daybyquest.post.dto.request.JudgePostRequest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class JudgePostService {
+
+    private final Posts posts;
+
+    private final ApplicationEventPublisher publisher;
+
+    public JudgePostService(final Posts posts, final ApplicationEventPublisher publisher) {
+        this.posts = posts;
+        this.publisher = publisher;
+    }
+
+    @Transactional
+    public void invoke(final Long postId, final JudgePostRequest request) {
+        final Post post = posts.getById(postId);
+        if (post.getQuestId() == null) {
+            throw new BadRequestException();
+        }
+        final Judgement judgement = Judgement.valueOf(request.getJudgement());
+        if (judgement == Judgement.SUCCESS) {
+            post.success();
+            publisher.publishEvent(new SuccessfullyPostLinkedEvent(post.getUserId(), post.getQuestId()));
+            return;
+        }
+        post.needCheck();
+    }
+}

--- a/src/main/java/daybyquest/post/domain/Judgement.java
+++ b/src/main/java/daybyquest/post/domain/Judgement.java
@@ -1,0 +1,7 @@
+package daybyquest.post.domain;
+
+public enum Judgement {
+
+    SUCCESS,
+    FAIL;
+}

--- a/src/main/java/daybyquest/post/domain/Post.java
+++ b/src/main/java/daybyquest/post/domain/Post.java
@@ -49,7 +49,7 @@ public class Post {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 15)
     @Enumerated(EnumType.STRING)
     private PostState state;
 

--- a/src/main/java/daybyquest/post/domain/Post.java
+++ b/src/main/java/daybyquest/post/domain/Post.java
@@ -1,7 +1,7 @@
 package daybyquest.post.domain;
 
+import static daybyquest.post.domain.PostState.NEED_CHECK;
 import static daybyquest.post.domain.PostState.NOT_DECIDED;
-import static daybyquest.post.domain.PostState.PREPARING;
 import static daybyquest.post.domain.PostState.SUCCESS;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -66,7 +66,7 @@ public class Post {
         this.questId = questId;
         this.content = content;
         this.images = images;
-        this.state = PREPARING;
+        this.state = NOT_DECIDED;
         validateUserId();
         validateImages();
         validateContent();
@@ -90,17 +90,17 @@ public class Post {
         }
     }
 
-    public void afterRequestDeciding() {
-        if (state != PREPARING || images == null) {
-            throw new InvalidDomainException();
-        }
-        state = NOT_DECIDED;
-    }
-
     public void success() {
-        if (state != PREPARING && state != NOT_DECIDED) {
+        if (state != NOT_DECIDED) {
             throw new InvalidDomainException();
         }
         state = SUCCESS;
+    }
+
+    public void needCheck() {
+        if (state != NOT_DECIDED) {
+            throw new InvalidDomainException();
+        }
+        state = NEED_CHECK;
     }
 }

--- a/src/main/java/daybyquest/post/domain/PostState.java
+++ b/src/main/java/daybyquest/post/domain/PostState.java
@@ -2,7 +2,6 @@ package daybyquest.post.domain;
 
 public enum PostState {
 
-    PREPARING,
     SUCCESS,
     NEED_CHECK,
     FAIL,

--- a/src/main/java/daybyquest/post/domain/SuccessfullyPostLinkedEvent.java
+++ b/src/main/java/daybyquest/post/domain/SuccessfullyPostLinkedEvent.java
@@ -1,0 +1,17 @@
+package daybyquest.post.domain;
+
+import daybyquest.global.event.Event;
+import lombok.Getter;
+
+@Getter
+public class SuccessfullyPostLinkedEvent implements Event {
+
+    private final Long userId;
+
+    private final Long questId;
+
+    public SuccessfullyPostLinkedEvent(final Long userId, final Long questId) {
+        this.userId = userId;
+        this.questId = questId;
+    }
+}

--- a/src/main/java/daybyquest/post/dto/request/JudgePostRequest.java
+++ b/src/main/java/daybyquest/post/dto/request/JudgePostRequest.java
@@ -1,0 +1,12 @@
+package daybyquest.post.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class JudgePostRequest {
+
+    private String judgement;
+
+}

--- a/src/main/java/daybyquest/post/presentation/PostCommandApi.java
+++ b/src/main/java/daybyquest/post/presentation/PostCommandApi.java
@@ -3,14 +3,18 @@ package daybyquest.post.presentation;
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
 import daybyquest.post.application.GetPostService;
+import daybyquest.post.application.JudgePostService;
 import daybyquest.post.application.SavePostService;
 import daybyquest.post.application.SwipePostService;
+import daybyquest.post.dto.request.JudgePostRequest;
 import daybyquest.post.dto.request.SavePostRequest;
 import daybyquest.post.dto.response.PostResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,11 +28,14 @@ public class PostCommandApi {
 
     private final GetPostService getPostService;
 
+    private final JudgePostService judgePostService;
+
     public PostCommandApi(final SavePostService savePostService, final SwipePostService swipePostService,
-            final GetPostService getPostService) {
+            final GetPostService getPostService, final JudgePostService judgePostService) {
         this.savePostService = savePostService;
         this.swipePostService = swipePostService;
         this.getPostService = getPostService;
+        this.judgePostService = judgePostService;
     }
 
     @PostMapping("/post")
@@ -45,6 +52,14 @@ public class PostCommandApi {
     @Authorization
     public ResponseEntity<Void> swipePost(final AccessUser accessUser, @PathVariable final Long postId) {
         swipePostService.invoke(accessUser.getId(), postId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/post/{postId}/judge")
+    @Authorization(admin = true)
+    public ResponseEntity<Void> swipePost(final AccessUser accessUser,
+            @PathVariable final Long postId, @RequestBody final JudgePostRequest request) {
+        judgePostService.invoke(postId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/daybyquest/quest/application/SaveQuestService.java
+++ b/src/main/java/daybyquest/quest/application/SaveQuestService.java
@@ -31,9 +31,9 @@ public class SaveQuestService {
     }
 
     @Transactional
-    public void invoke(final SaveQuestRequest request, final List<MultipartFile> files) {
+    public Long invoke(final SaveQuestRequest request, final List<MultipartFile> files) {
         final Quest quest = toEntity(request, toImageList(files));
-        quests.save(quest);
+        return quests.save(quest);
     }
 
     private List<Image> toImageList(final List<MultipartFile> files) {

--- a/src/main/java/daybyquest/quest/domain/QuestRepository.java
+++ b/src/main/java/daybyquest/quest/domain/QuestRepository.java
@@ -5,8 +5,9 @@ import org.springframework.data.repository.Repository;
 
 interface QuestRepository extends Repository<Quest, Long> {
 
-    Quest save(Quest quest);
+    Quest save(final Quest quest);
 
-    Optional<Quest> findById(Long id);
+    Optional<Quest> findById(final Long id);
 
+    boolean existsById(final Long id);
 }

--- a/src/main/java/daybyquest/quest/domain/Quests.java
+++ b/src/main/java/daybyquest/quest/domain/Quests.java
@@ -1,5 +1,6 @@
 package daybyquest.quest.domain;
 
+import daybyquest.global.error.exception.NotExistQuestException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,5 +14,11 @@ public class Quests {
 
     public void save(final Quest quest) {
         questRepository.save(quest);
+    }
+
+    public void validateExistentById(final Long id) {
+        if (!questRepository.existsById(id)) {
+            throw new NotExistQuestException();
+        }
     }
 }

--- a/src/main/java/daybyquest/quest/domain/Quests.java
+++ b/src/main/java/daybyquest/quest/domain/Quests.java
@@ -12,13 +12,11 @@ public class Quests {
         this.questRepository = questRepository;
     }
 
-    public void save(final Quest quest) {
-        questRepository.save(quest);
+    public Long save(final Quest quest) {
+        return questRepository.save(quest).getId();
     }
 
-    public void validateExistentById(final Long id) {
-        if (!questRepository.existsById(id)) {
-            throw new NotExistQuestException();
-        }
+    public Quest getById(final Long id) {
+        return questRepository.findById(id).orElseThrow(NotExistQuestException::new);
     }
 }

--- a/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
+++ b/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
@@ -2,8 +2,10 @@ package daybyquest.quest.presentation;
 
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
+import daybyquest.quest.application.GetQuestByIdService;
 import daybyquest.quest.application.SaveQuestService;
 import daybyquest.quest.dto.request.SaveQuestRequest;
+import daybyquest.quest.dto.response.QuestResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,16 +18,21 @@ public class QuestCommandApi {
 
     private final SaveQuestService saveQuestService;
 
-    public QuestCommandApi(final SaveQuestService saveQuestService) {
+    private final GetQuestByIdService getQuestByIdService;
+
+    public QuestCommandApi(final SaveQuestService saveQuestService,
+            final GetQuestByIdService getQuestByIdService) {
         this.saveQuestService = saveQuestService;
+        this.getQuestByIdService = getQuestByIdService;
     }
 
     @PostMapping("/quest")
     @Authorization(admin = true)
-    public ResponseEntity<Void> saveQuest(final AccessUser accessUser,
+    public ResponseEntity<QuestResponse> saveQuest(final AccessUser accessUser,
             @RequestPart SaveQuestRequest request,
             @RequestPart List<MultipartFile> files) {
-        saveQuestService.invoke(request, files);
-        return ResponseEntity.ok().build();
+        final Long questId = saveQuestService.invoke(request, files);
+        final QuestResponse response = getQuestByIdService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
@@ -1,6 +1,7 @@
 package daybyquest.quest.query;
 
 import static daybyquest.participant.domain.QParticipant.participant;
+import static daybyquest.post.domain.PostState.SUCCESS;
 import static daybyquest.post.domain.QPost.post;
 import static daybyquest.quest.domain.QQuest.quest;
 
@@ -32,9 +33,10 @@ public class QuestDaoQuerydslImpl implements QuestDao {
                         quest.rewardCount,
                         JPAExpressions.select(post.count())
                                 .from(post)
-                                .where(post.userId.eq(userId), post.questId.eq(id))
+                                .where(post.userId.eq(userId), post.questId.eq(id), post.state.eq(SUCCESS))
                 ))
                 .from(quest)
+                .where(quest.id.eq(id))
                 .fetchOne();
         if (data == null) {
             throw new NotExistQuestException();
@@ -42,7 +44,7 @@ public class QuestDaoQuerydslImpl implements QuestDao {
 
         ParticipantState state = factory.select(participant.state)
                 .from(participant)
-                .where(participant.userId.eq(userId), participant.questId.eq(id))
+                .where(participant.userId.eq(userId), participant.quest.id.eq(id))
                 .fetchOne();
         if (state == null) {
             state = ParticipantState.NOT;


### PR DESCRIPTION
## 🗒️ Summary
- 수행, 삭제 기능 구현
- 퀘스트 완료, 재개, 보상 받기 구현
- 게시물 AI에 의한 판정 구현
### 리팩토링
- `Pariticipant`가 `Quest`를 `ManyToOne` 연관관계를 통해 갖도록 변경
  - 연관성이 매우 깊으며, 검증 로직에도 필요하므로 변경하였음 

> #58 

## 💡 More
- 