### PR TITLE
[Feature] 뱃지 설정, 사용자 이름을 통한 뱃지 목록 조회를 구현한다

### DIFF
--- a/src/main/java/daybyquest/badge/domain/Owning.java
+++ b/src/main/java/daybyquest/badge/domain/Owning.java
@@ -35,4 +35,8 @@ public class Owning {
         this.userId = userId;
         this.badge = badge;
     }
+
+    public Long getBadgeId() {
+        return badge.getId();
+    }
 }

--- a/src/main/java/daybyquest/badge/domain/OwningRepository.java
+++ b/src/main/java/daybyquest/badge/domain/OwningRepository.java
@@ -1,12 +1,14 @@
 package daybyquest.badge.domain;
 
-import java.util.Optional;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 interface OwningRepository extends Repository<Owning, OwningId> {
 
     Owning save(final Owning owning);
 
-    Optional<Owning> findByUserId(final Long userId);
-
+    @Query("SELECT o  FROM Owning o WHERE o.userId=:userId and o.badge.id IN :badgeIds")
+    List<Owning> findAllByUserIdAndBadgeIdIn(final Long userId, final Collection<Long> badgeIds);
 }

--- a/src/main/java/daybyquest/badge/domain/Ownings.java
+++ b/src/main/java/daybyquest/badge/domain/Ownings.java
@@ -1,6 +1,11 @@
 package daybyquest.badge.domain;
 
+import static daybyquest.global.error.ExceptionCode.NOT_OWNING_BADGE;
+
+import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.user.domain.Users;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,5 +30,21 @@ public class Ownings {
 
     private void save(final Owning owning) {
         owningRepository.save(owning);
+    }
+
+    public void validateOwningByBadgeIds(final Long userId, final List<Long> badgeIds) {
+        final List<Owning> ownings = owningRepository.findAllByUserIdAndBadgeIdIn(userId, badgeIds);
+        if (ownings.size() != badgeIds.size()) {
+            throw new InvalidDomainException(NOT_OWNING_BADGE);
+        }
+        ownings.forEach(
+                owning -> validateContainOwning(badgeIds, owning)
+        );
+    }
+
+    private void validateContainOwning(final Collection<Long> badgeIds, final Owning owning) {
+        if (!badgeIds.contains(owning.getBadgeId())) {
+            throw new InvalidDomainException(NOT_OWNING_BADGE);
+        }
     }
 }

--- a/src/main/java/daybyquest/badge/dto/response/MultipleBadgesResponse.java
+++ b/src/main/java/daybyquest/badge/dto/response/MultipleBadgesResponse.java
@@ -1,0 +1,7 @@
+package daybyquest.badge.dto.response;
+
+import java.util.List;
+
+public record MultipleBadgesResponse(List<BadgeResponse> badges) {
+
+}

--- a/src/main/java/daybyquest/badge/query/BadgeDao.java
+++ b/src/main/java/daybyquest/badge/query/BadgeDao.java
@@ -1,9 +1,12 @@
 package daybyquest.badge.query;
 
 import daybyquest.global.query.NoOffsetTimePage;
+import java.util.Collection;
 import java.util.List;
 
 public interface BadgeDao {
 
     List<BadgeData> getBadgePageByUserIds(final Long userId, final NoOffsetTimePage page);
+
+    List<BadgeData> findAllByIdIn(final Collection<Long> ids);
 }

--- a/src/main/java/daybyquest/global/error/ExceptionCode.java
+++ b/src/main/java/daybyquest/global/error/ExceptionCode.java
@@ -80,7 +80,7 @@ public enum ExceptionCode {
     // Badge
     NOT_EXIST_BADGE("BDE-00", BAD_REQUEST, "존재하지 않는 뱃지입니다"),
     NOT_OWNING_BADGE("BDE-01", BAD_REQUEST, "보유하지 않은 뱃지는 프로필에 배치할 수 없습니다"),
-    EXCEED_BADGE("BDE-02", BAD_REQUEST, "뱃지는 최대 15개만 지정가능합니다"),
+    EXCEED_BADGE("BDE-02", BAD_REQUEST, "뱃지는 최대 10개만 지정가능합니다"),
     INVALID_BADGE_NAME("BDE-03", BAD_REQUEST, "뱃지 이름은 1~15글자여야 합니다."),
 
     // Interest

--- a/src/main/java/daybyquest/profile/application/GetPresetBadgeService.java
+++ b/src/main/java/daybyquest/profile/application/GetPresetBadgeService.java
@@ -1,0 +1,36 @@
+package daybyquest.profile.application;
+
+import daybyquest.badge.dto.response.BadgeResponse;
+import daybyquest.badge.dto.response.MultipleBadgesResponse;
+import daybyquest.badge.query.BadgeDao;
+import daybyquest.profile.domain.ProfileSettings;
+import daybyquest.user.domain.Users;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetPresetBadgeService {
+
+    private final Users users;
+
+    private final ProfileSettings profileSettings;
+
+    private final BadgeDao badgeDao;
+
+    public GetPresetBadgeService(final Users users, final ProfileSettings profileSettings,
+            final BadgeDao badgeDao) {
+        this.users = users;
+        this.profileSettings = profileSettings;
+        this.badgeDao = badgeDao;
+    }
+
+    @Transactional(readOnly = true)
+    public MultipleBadgesResponse invoke(final Long loginId, final String username) {
+        final Long userId = users.getUserIdByUsername(username);
+        final List<Long> badgeIds = profileSettings.getById(loginId).getBadgeIds();
+        final List<BadgeResponse> responses = badgeDao.findAllByIdIn(badgeIds)
+                .stream().map(BadgeResponse::of).toList();
+        return new MultipleBadgesResponse(responses);
+    }
+}

--- a/src/main/java/daybyquest/profile/application/SaveBadgeListService.java
+++ b/src/main/java/daybyquest/profile/application/SaveBadgeListService.java
@@ -1,0 +1,30 @@
+package daybyquest.profile.application;
+
+import daybyquest.badge.domain.Ownings;
+import daybyquest.profile.domain.ProfileSetting;
+import daybyquest.profile.domain.ProfileSettings;
+import daybyquest.profile.dto.request.SaveBadgeListRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SaveBadgeListService {
+
+    private final ProfileSettings profileSettings;
+
+    private final Ownings ownings;
+
+    public SaveBadgeListService(final ProfileSettings profileSettings, final Ownings ownings) {
+        this.profileSettings = profileSettings;
+        this.ownings = ownings;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final SaveBadgeListRequest request) {
+        if (request.getBadgeIds() != null) {
+            ownings.validateOwningByBadgeIds(loginId, request.getBadgeIds());
+        }
+        final ProfileSetting profileSetting = profileSettings.getById(loginId);
+        profileSetting.updateBadgeList(request.getBadgeIds());
+    }
+}

--- a/src/main/java/daybyquest/profile/domain/ProfileBadgeIdsConverter.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileBadgeIdsConverter.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Converter
-public class ProfileBadgeListConverter implements AttributeConverter<List<Long>, String> {
+public class ProfileBadgeIdsConverter implements AttributeConverter<List<Long>, String> {
 
     @Override
     public String convertToDatabaseColumn(List<Long> attribute) {

--- a/src/main/java/daybyquest/profile/domain/ProfileBadgeListConverter.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileBadgeListConverter.java
@@ -10,8 +10,8 @@ public class ProfileBadgeListConverter implements AttributeConverter<List<Long>,
 
     @Override
     public String convertToDatabaseColumn(List<Long> attribute) {
-        if (attribute == null) {
-            return null;
+        if (attribute == null || attribute.isEmpty()) {
+            return "";
         }
         final List<String> attributeStrings = attribute.stream().map(String::valueOf).toList();
         return String.join(",", attributeStrings);
@@ -19,7 +19,7 @@ public class ProfileBadgeListConverter implements AttributeConverter<List<Long>,
 
     @Override
     public List<Long> convertToEntityAttribute(String dbData) {
-        if (dbData == null) {
+        if (dbData == null || dbData.isEmpty()) {
             return Collections.emptyList();
         }
         final List<String> attributeStrings = List.of(dbData.split(","));

--- a/src/main/java/daybyquest/profile/domain/ProfileSetting.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileSetting.java
@@ -24,25 +24,25 @@ public class ProfileSetting {
     private Long userId;
 
     @Column
-    @Convert(converter = ProfileBadgeListConverter.class)
-    private List<Long> badgeList;
+    @Convert(converter = ProfileBadgeIdsConverter.class)
+    private List<Long> badgeIds;
 
     public ProfileSetting(final Long userId) {
         this.userId = userId;
-        this.badgeList = Collections.emptyList();
+        this.badgeIds = Collections.emptyList();
     }
 
-    public void updateBadgeList(final List<Long> badgeList) {
-        if (badgeList == null) {
-            this.badgeList = Collections.emptyList();
+    public void updateBadgeList(final List<Long> badgeIds) {
+        if (badgeIds == null) {
+            this.badgeIds = Collections.emptyList();
             return;
         }
-        this.badgeList = badgeList;
+        this.badgeIds = badgeIds;
         validateBadgeList();
     }
 
     private void validateBadgeList() {
-        if (badgeList.size() > MAX_BADGE_LIST_SIZE) {
+        if (badgeIds.size() > MAX_BADGE_LIST_SIZE) {
             throw new InvalidDomainException(EXCEED_BADGE);
         }
     }

--- a/src/main/java/daybyquest/profile/domain/ProfileSetting.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileSetting.java
@@ -1,12 +1,14 @@
 package daybyquest.profile.domain;
 
+import static daybyquest.global.error.ExceptionCode.EXCEED_BADGE;
 import static lombok.AccessLevel.PROTECTED;
 
+import daybyquest.global.error.exception.InvalidDomainException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
-import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +18,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class ProfileSetting {
 
+    private static final int MAX_BADGE_LIST_SIZE = 10;
+
     @Id
     private Long userId;
 
@@ -23,4 +27,23 @@ public class ProfileSetting {
     @Convert(converter = ProfileBadgeListConverter.class)
     private List<Long> badgeList;
 
+    public ProfileSetting(final Long userId) {
+        this.userId = userId;
+        this.badgeList = Collections.emptyList();
+    }
+
+    public void updateBadgeList(final List<Long> badgeList) {
+        if (badgeList == null) {
+            this.badgeList = Collections.emptyList();
+            return;
+        }
+        this.badgeList = badgeList;
+        validateBadgeList();
+    }
+
+    private void validateBadgeList() {
+        if (badgeList.size() > MAX_BADGE_LIST_SIZE) {
+            throw new InvalidDomainException(EXCEED_BADGE);
+        }
+    }
 }

--- a/src/main/java/daybyquest/profile/domain/ProfileSettingRepository.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileSettingRepository.java
@@ -3,7 +3,7 @@ package daybyquest.profile.domain;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
-public interface ProfileSettingRepository extends Repository<ProfileSetting, Long> {
+interface ProfileSettingRepository extends Repository<ProfileSetting, Long> {
 
     ProfileSetting save(ProfileSetting profileSetting);
 

--- a/src/main/java/daybyquest/profile/domain/ProfileSettings.java
+++ b/src/main/java/daybyquest/profile/domain/ProfileSettings.java
@@ -1,0 +1,22 @@
+package daybyquest.profile.domain;
+
+import daybyquest.global.error.exception.NotExistUserException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfileSettings {
+
+    private final ProfileSettingRepository profileSettingRepository;
+
+    ProfileSettings(final ProfileSettingRepository profileSettingRepository) {
+        this.profileSettingRepository = profileSettingRepository;
+    }
+
+    public void save(final ProfileSetting profileSetting) {
+        profileSettingRepository.save(profileSetting);
+    }
+
+    public ProfileSetting getById(final Long userId) {
+        return profileSettingRepository.findByUserId(userId).orElseThrow(NotExistUserException::new);
+    }
+}

--- a/src/main/java/daybyquest/profile/dto/request/SaveBadgeListRequest.java
+++ b/src/main/java/daybyquest/profile/dto/request/SaveBadgeListRequest.java
@@ -1,0 +1,12 @@
+package daybyquest.profile.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SaveBadgeListRequest {
+
+    private List<Long> badgeIds;
+}

--- a/src/main/java/daybyquest/profile/listener/SaveProfileSettingListener.java
+++ b/src/main/java/daybyquest/profile/listener/SaveProfileSettingListener.java
@@ -1,0 +1,23 @@
+package daybyquest.profile.listener;
+
+import daybyquest.profile.domain.ProfileSetting;
+import daybyquest.profile.domain.ProfileSettings;
+import daybyquest.user.domain.UserSavedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SaveProfileSettingListener {
+
+    private final ProfileSettings profileSettings;
+
+    public SaveProfileSettingListener(final ProfileSettings profileSettings) {
+        this.profileSettings = profileSettings;
+    }
+
+    @EventListener
+    public void listenUserSavedEvent(final UserSavedEvent event) {
+        final ProfileSetting profileSetting = new ProfileSetting(event.userId());
+        profileSettings.save(profileSetting);
+    }
+}

--- a/src/main/java/daybyquest/profile/presentation/ProfileQueryApi.java
+++ b/src/main/java/daybyquest/profile/presentation/ProfileQueryApi.java
@@ -1,0 +1,28 @@
+package daybyquest.profile.presentation;
+
+import daybyquest.auth.Authorization;
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.badge.dto.response.MultipleBadgesResponse;
+import daybyquest.profile.application.GetPresetBadgeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProfileQueryApi {
+
+    private final GetPresetBadgeService getPresetBadgeService;
+
+    public ProfileQueryApi(final GetPresetBadgeService getPresetBadgeService) {
+        this.getPresetBadgeService = getPresetBadgeService;
+    }
+
+    @GetMapping("/badge/{username}")
+    @Authorization
+    public ResponseEntity<MultipleBadgesResponse> getBadges(final AccessUser user,
+            @PathVariable final String username) {
+        final MultipleBadgesResponse response = getPresetBadgeService.invoke(user.getId(), username);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/daybyquest/profile/presentation/ProfileSettingCommandApi.java
+++ b/src/main/java/daybyquest/profile/presentation/ProfileSettingCommandApi.java
@@ -1,0 +1,29 @@
+package daybyquest.profile.presentation;
+
+import daybyquest.auth.Authorization;
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.profile.application.SaveBadgeListService;
+import daybyquest.profile.dto.request.SaveBadgeListRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProfileSettingCommandApi {
+
+    private final SaveBadgeListService saveBadgeListService;
+
+    public ProfileSettingCommandApi(final SaveBadgeListService saveBadgeListService) {
+        this.saveBadgeListService = saveBadgeListService;
+    }
+
+    @PatchMapping("/badge")
+    @Authorization
+    public ResponseEntity<Void> saveBadgeList(final AccessUser accessUser,
+            @RequestBody @Valid final SaveBadgeListRequest request) {
+        saveBadgeListService.invoke(accessUser.getId(), request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/daybyquest/user/application/SaveUserService.java
+++ b/src/main/java/daybyquest/user/application/SaveUserService.java
@@ -3,8 +3,10 @@ package daybyquest.user.application;
 import daybyquest.image.domain.BaseImageProperties;
 import daybyquest.image.domain.Image;
 import daybyquest.user.domain.User;
+import daybyquest.user.domain.UserSavedEvent;
 import daybyquest.user.domain.Users;
 import daybyquest.user.dto.request.SaveUserRequest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,15 +17,19 @@ public class SaveUserService {
 
     private final BaseImageProperties baseImageProperties;
 
-    public SaveUserService(final Users users, final BaseImageProperties baseImageProperties) {
+    private final ApplicationEventPublisher publisher;
+
+    public SaveUserService(final Users users, final BaseImageProperties baseImageProperties,
+            final ApplicationEventPublisher publisher) {
         this.users = users;
         this.baseImageProperties = baseImageProperties;
+        this.publisher = publisher;
     }
 
     @Transactional
     public Long invoke(final SaveUserRequest request) {
-        final User user = toEntity(request);
-        final User savedUser = users.save(user);
+        final User savedUser = users.save(toEntity(request));
+        publisher.publishEvent(new UserSavedEvent(savedUser.getId()));
         return savedUser.getId();
     }
 

--- a/src/main/java/daybyquest/user/domain/UserSavedEvent.java
+++ b/src/main/java/daybyquest/user/domain/UserSavedEvent.java
@@ -1,0 +1,5 @@
+package daybyquest.user.domain;
+
+public record UserSavedEvent(Long userId) {
+
+}

--- a/src/main/resources/db/migration/V3__rename_profile_setting.sql
+++ b/src/main/resources/db/migration/V3__rename_profile_setting.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `profile_setting`
+    RENAME COLUMN `badge_list` TO `badge_ids`

--- a/src/test/java/daybyquest/badge/domain/OwningsTest.java
+++ b/src/test/java/daybyquest/badge/domain/OwningsTest.java
@@ -1,11 +1,16 @@
 package daybyquest.badge.domain;
 
 import static daybyquest.support.fixture.BadgeFixtures.BADGE_1;
+import static daybyquest.support.fixture.BadgeFixtures.BADGE_2;
+import static daybyquest.support.fixture.BadgeFixtures.BADGE_3;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.user.domain.Users;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -53,5 +58,40 @@ public class OwningsTest {
 
         // then
         then(users).should().validateExistentById(userId);
+    }
+
+    @Test
+    void 사용자가_뱃지들을_보유하고_있는지_ID를_통해_검증한다() {
+        // given
+        final Long userId = 1L;
+        final List<Owning> owningList = List.of(
+                new Owning(userId, BADGE_1.생성(2L)),
+                new Owning(userId, BADGE_2.생성(3L)),
+                new Owning(userId, BADGE_3.생성(4L))
+        );
+        final List<Long> badgeIds = owningList.stream().map(Owning::getBadgeId).toList();
+        given(owningRepository.findAllByUserIdAndBadgeIdIn(userId, badgeIds)).willReturn(owningList);
+
+        // when
+        ownings.validateOwningByBadgeIds(userId, badgeIds);
+
+        // then
+        then(owningRepository).should().findAllByUserIdAndBadgeIdIn(userId, badgeIds);
+    }
+
+    @Test
+    void 사용자가_뱃지들을_보유하고_있는지_검증_시_하나라도_없으면_예외를_던진다() {
+        // given
+        final Long userId = 1L;
+        final List<Owning> owningList = List.of(
+                new Owning(userId, BADGE_1.생성(2L)),
+                new Owning(userId, BADGE_2.생성(3L))
+        );
+        final List<Long> badgeIds = List.of(2L, 3L, 4L);
+        given(owningRepository.findAllByUserIdAndBadgeIdIn(userId, badgeIds)).willReturn(owningList);
+
+        // when & then
+        assertThatThrownBy(() -> ownings.validateOwningByBadgeIds(userId, badgeIds))
+                .isInstanceOf(InvalidDomainException.class);
     }
 }

--- a/src/test/java/daybyquest/badge/query/BadgeDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/badge/query/BadgeDaoQuerydslImplTest.java
@@ -84,4 +84,28 @@ public class BadgeDaoQuerydslImplTest extends QuerydslTest {
             assertThat(actual.getImageIdentifier()).isEqualTo(BADGE_1.imageIdentifier);
         });
     }
+
+    @Test
+    void 컬렉션으로_뱃지를_조회한다() {
+        // given
+        final User bob = 저장한다(BOB.생성());
+        final Badge badge1 = 저장한다(BADGE_1.생성());
+        final Badge badge2 = 저장한다(BADGE_2.생성());
+        저장한다(BADGE_3.생성());
+
+        저장한다(new Owning(bob.getId(), badge1));
+        저장한다(new Owning(bob.getId(), badge2));
+
+        final List<Long> ids = List.of(badge1.getId(), badge2.getId());
+
+        // when
+        final List<BadgeData> badgeData = badgeDao.findAllByIdIn(ids);
+        final List<Long> actualIds = badgeData.stream().map(BadgeData::getId).toList();
+
+        // then
+        assertAll(() -> {
+            assertThat(badgeData).hasSize(ids.size());
+            assertThat(actualIds).containsExactlyElementsOf(ids);
+        });
+    }
 }

--- a/src/test/java/daybyquest/profile/domain/ProfileSettingTest.java
+++ b/src/test/java/daybyquest/profile/domain/ProfileSettingTest.java
@@ -1,0 +1,23 @@
+package daybyquest.profile.domain;
+
+import static daybyquest.global.error.ExceptionCode.EXCEED_BADGE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ProfileSettingTest {
+
+    @Test
+    void 뱃지_ID가_10개를_넘으면_예외를_던진다() {
+        // given
+        final ProfileSetting profileSetting = new ProfileSetting(1L);
+        final List<Long> badgeIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 6L, 7L, 8L, 9L, 10L, 11L);
+
+        // when & then
+        assertThatThrownBy(() -> profileSetting.updateBadgeList(badgeIds))
+                .isInstanceOf(InvalidDomainException.class)
+                .hasMessageContaining(EXCEED_BADGE.getMessage());
+    }
+}

--- a/src/test/java/daybyquest/profile/domain/ProfileSettingsTest.java
+++ b/src/test/java/daybyquest/profile/domain/ProfileSettingsTest.java
@@ -1,0 +1,56 @@
+package daybyquest.profile.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import daybyquest.global.error.exception.NotExistUserException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfileSettingsTest {
+
+    @Mock
+    private ProfileSettingRepository profileSettingRepository;
+
+    @InjectMocks
+    private ProfileSettings profileSettings;
+
+    @Test
+    void 프로필_설정을_저장한다() {
+        // given & when
+        profileSettings.save(new ProfileSetting(1L));
+
+        // then
+        then(profileSettingRepository).should().save(any(ProfileSetting.class));
+    }
+
+    @Test
+    void 사용자_ID를_통해_프로필_설정을_조회한다() {
+        // given
+        final Long userId = 1L;
+        final ProfileSetting expected = new ProfileSetting(userId);
+        given(profileSettingRepository.findByUserId(userId))
+                .willReturn(Optional.of(expected));
+
+        // when
+        final ProfileSetting actual = profileSettings.getById(userId);
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    void 사용자_ID를_통한_조회_시_없다면_예외를_던진다() {
+        // given & when & then
+        assertThatThrownBy(() -> profileSettings.getById(1L))
+                .isInstanceOf(NotExistUserException.class);
+    }
+}


### PR DESCRIPTION
## 🗒️ Summary
### 기능 구현
- 프로필에 표시할 뱃지 목록 설정
- 사용자 이름을 통한 미리 설정된 뱃지 목록 조회
### 그 외 변경 사항
- `ProfileSetting`내 `badgeList` 변수를 `badgeIds`로 변경
- `BadgeIdsConverter`가 `badgeIds`가 비어있는 경우 `null`이 아닌 빈 문자열로 변환함
- 프로필 설정 테스트 작성

>resolve: #66

## 💡 More
- 