### PR TITLE
[Feature] 내 퀘스트 목록 조회를 구현한다

### DIFF
--- a/src/main/java/daybyquest/global/config/WebMvcConfig.java
+++ b/src/main/java/daybyquest/global/config/WebMvcConfig.java
@@ -3,6 +3,7 @@ package daybyquest.global.config;
 import daybyquest.auth.AccessUserArgumentResolver;
 import daybyquest.global.query.NoOffsetIdPageArgumentResolver;
 import daybyquest.global.query.NoOffsetTimePageArgumentResolver;
+import daybyquest.participant.presentation.ParticipantStateArgumentResolver;
 import daybyquest.user.domain.Users;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
@@ -25,5 +26,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
         resolvers.add(new AccessUserArgumentResolver(users));
         resolvers.add(new NoOffsetIdPageArgumentResolver());
         resolvers.add(new NoOffsetTimePageArgumentResolver());
+        resolvers.add(new ParticipantStateArgumentResolver());
     }
 }

--- a/src/main/java/daybyquest/global/error/ExceptionCode.java
+++ b/src/main/java/daybyquest/global/error/ExceptionCode.java
@@ -66,6 +66,7 @@ public enum ExceptionCode {
     INVALID_QUEST_EXPIRED_AT("QUE-15", BAD_REQUEST, "만료일자는 현재보다 미래여야 합니다"),
     ALREADY_LABELED("QUE-16", BAD_REQUEST, "이미 라벨링된 퀘스트입니다"),
     INVALID_QUEST_IMAGE("QUE-17", BAD_REQUEST, "퀘스트 사진이 없습니다"),
+    ALREADY_EXIST_REWARD("QUE-18", BAD_REQUEST, "이미 보상으로 설정된 뱃지입니다"),
 
     // Group
     NOT_EXIST_GROUP("GRP-00", BAD_REQUEST, "존재하지 않는 그룹입니다"),

--- a/src/main/java/daybyquest/global/error/ExceptionCode.java
+++ b/src/main/java/daybyquest/global/error/ExceptionCode.java
@@ -61,10 +61,11 @@ public enum ExceptionCode {
     INVALID_QUEST_CONTENT("QUE-10", BAD_REQUEST, "퀘스트 내용은 300자 이하여야 합니다"),
     INVALID_QUEST_IMAGE_DESCRIPTION("QUE-11", BAD_REQUEST, "퀘스트 사진 설명은 1~100자여야 합니다"),
     INVALID_QUEST_REWARD_COUNT("QUE-12", BAD_REQUEST, "목표 횟수는 1~365이어야 합니다"),
-    INVALID_QUEST_IMAGE("QUE-13", BAD_REQUEST, "퀘스트 사진은 3장이어야 합니다"),
+    INVALID_QUEST_IMAGES("QUE-13", BAD_REQUEST, "퀘스트 사진은 3장이어야 합니다"),
     INVALID_QUEST_REWARD("QUE-14", BAD_REQUEST, "보상과 목표 횟수는 둘 중 하나만 존재할 수 없습니다"),
     INVALID_QUEST_EXPIRED_AT("QUE-15", BAD_REQUEST, "만료일자는 현재보다 미래여야 합니다"),
     ALREADY_LABELED("QUE-16", BAD_REQUEST, "이미 라벨링된 퀘스트입니다"),
+    INVALID_QUEST_IMAGE("QUE-17", BAD_REQUEST, "퀘스트 사진이 없습니다"),
 
     // Group
     NOT_EXIST_GROUP("GRP-00", BAD_REQUEST, "존재하지 않는 그룹입니다"),

--- a/src/main/java/daybyquest/participant/application/GetQuestsService.java
+++ b/src/main/java/daybyquest/participant/application/GetQuestsService.java
@@ -1,0 +1,32 @@
+package daybyquest.participant.application;
+
+import daybyquest.participant.domain.ParticipantState;
+import daybyquest.participant.query.ParticipantDao;
+import daybyquest.quest.dto.response.MultipleQuestsResponse;
+import daybyquest.quest.dto.response.QuestResponse;
+import daybyquest.quest.query.QuestDao;
+import daybyquest.quest.query.QuestData;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetQuestsService {
+
+    private final ParticipantDao participantDao;
+
+    private final QuestDao questDao;
+
+    public GetQuestsService(final ParticipantDao participantDao, final QuestDao questDao) {
+        this.participantDao = participantDao;
+        this.questDao = questDao;
+    }
+
+    @Transactional(readOnly = true)
+    public MultipleQuestsResponse invoke(final Long loginId, final ParticipantState state) {
+        final List<Long> ids = participantDao.findIdsByUserIdAndState(loginId, state);
+        final List<QuestData> questData = questDao.findAllByIdIn(loginId, ids);
+        final List<QuestResponse> responses = questData.stream().map(QuestResponse::of).toList();
+        return new MultipleQuestsResponse(responses);
+    }
+}

--- a/src/main/java/daybyquest/participant/presentation/ParticipantQueryApi.java
+++ b/src/main/java/daybyquest/participant/presentation/ParticipantQueryApi.java
@@ -1,0 +1,28 @@
+package daybyquest.participant.presentation;
+
+import daybyquest.auth.Authorization;
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.participant.application.GetQuestsService;
+import daybyquest.participant.domain.ParticipantState;
+import daybyquest.quest.dto.response.MultipleQuestsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ParticipantQueryApi {
+
+    private final GetQuestsService getQuestsService;
+
+    public ParticipantQueryApi(final GetQuestsService getQuestsService) {
+        this.getQuestsService = getQuestsService;
+    }
+
+    @GetMapping("/quest")
+    @Authorization
+    public ResponseEntity<MultipleQuestsResponse> getQuestsByState(final AccessUser accessUser,
+            final ParticipantState state) {
+        final MultipleQuestsResponse response = getQuestsService.invoke(accessUser.getId(), state);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/daybyquest/participant/presentation/ParticipantStateArgumentResolver.java
+++ b/src/main/java/daybyquest/participant/presentation/ParticipantStateArgumentResolver.java
@@ -1,0 +1,34 @@
+package daybyquest.participant.presentation;
+
+import static daybyquest.global.error.ExceptionCode.INVALID_REQUEST;
+
+import daybyquest.global.error.exception.BadRequestException;
+import daybyquest.participant.domain.ParticipantState;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class ParticipantStateArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String STATE_PARAMETER = "state";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(ParticipantState.class);
+    }
+
+    @Override
+    public Object resolveArgument(@Nonnull MethodParameter parameter, ModelAndViewContainer mavContainer,
+            @Nonnull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final String stateArgument = webRequest.getParameter(STATE_PARAMETER);
+        try {
+            return ParticipantState.valueOf(stateArgument);
+        } catch (final IllegalArgumentException e) {
+            throw new BadRequestException(INVALID_REQUEST, List.of(STATE_PARAMETER));
+        }
+    }
+}

--- a/src/main/java/daybyquest/participant/query/ParticipantDao.java
+++ b/src/main/java/daybyquest/participant/query/ParticipantDao.java
@@ -1,0 +1,9 @@
+package daybyquest.participant.query;
+
+import daybyquest.participant.domain.ParticipantState;
+import java.util.List;
+
+public interface ParticipantDao {
+
+    List<Long> findIdsByUserIdAndState(final Long userId, final ParticipantState state);
+}

--- a/src/main/java/daybyquest/participant/query/ParticipantDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/participant/query/ParticipantDaoQuerydslImpl.java
@@ -1,0 +1,29 @@
+package daybyquest.participant.query;
+
+import static daybyquest.participant.domain.QParticipant.participant;
+import static daybyquest.quest.domain.QQuest.quest;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import daybyquest.participant.domain.ParticipantState;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ParticipantDaoQuerydslImpl implements ParticipantDao {
+
+    private final JPAQueryFactory factory;
+
+    public ParticipantDaoQuerydslImpl(final JPAQueryFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public List<Long> findIdsByUserIdAndState(final Long userId,
+            final ParticipantState state) {
+        return factory.select(quest.id)
+                .from(participant)
+                .innerJoin(participant.quest, quest)
+                .where(participant.userId.eq(userId), participant.state.eq(state))
+                .fetch();
+    }
+}

--- a/src/main/java/daybyquest/quest/application/SaveQuestService.java
+++ b/src/main/java/daybyquest/quest/application/SaveQuestService.java
@@ -1,5 +1,7 @@
 package daybyquest.quest.application;
 
+import daybyquest.badge.domain.Badge;
+import daybyquest.badge.domain.Badges;
 import daybyquest.global.utils.MultipartFileUtils;
 import daybyquest.image.domain.Image;
 import daybyquest.image.domain.ImageIdentifierGenerator;
@@ -19,13 +21,16 @@ public class SaveQuestService {
 
     private final Quests quests;
 
+    private final Badges badges;
+
     private final Images images;
 
     private final ImageIdentifierGenerator generator;
 
-    public SaveQuestService(final Quests quests, final Images images,
+    public SaveQuestService(final Quests quests, final Badges badges, final Images images,
             final ImageIdentifierGenerator generator) {
         this.quests = quests;
+        this.badges = badges;
         this.images = images;
         this.generator = generator;
     }
@@ -44,7 +49,9 @@ public class SaveQuestService {
     }
 
     private Quest toEntity(final SaveQuestRequest request, final List<Image> images) {
-        return Quest.createNormalQuest(request.getBadgeId(), request.getInterest(), request.getTitle(),
-                request.getContent(), request.getRewardCount(), request.getImageDescription(), images);
+        final Badge badge = badges.getById(request.getBadgeId());
+        return Quest.createNormalQuest(badge.getId(), request.getInterest(), request.getTitle(),
+                request.getContent(), request.getRewardCount(), request.getImageDescription(), images,
+                badge.getImage());
     }
 }

--- a/src/main/java/daybyquest/quest/domain/Quest.java
+++ b/src/main/java/daybyquest/quest/domain/Quest.java
@@ -3,7 +3,7 @@ package daybyquest.quest.domain;
 import static daybyquest.global.error.ExceptionCode.ALREADY_LABELED;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_CONTENT;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_EXPIRED_AT;
-import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_IMAGE;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_IMAGES;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_IMAGE_DESCRIPTION;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_NAME;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_REWARD;
@@ -18,6 +18,7 @@ import daybyquest.image.domain.Image;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
@@ -92,9 +93,13 @@ public class Quest {
     @CollectionTable(name = "quest_image", joinColumns = @JoinColumn(name = "quest_id"))
     private List<Image> images;
 
+    @Embedded
+    private Image image;
+
     private Quest(final Long groupId, final Long badgeId, final String interestName, final String title,
             final String content, final QuestCategory category, final Long rewardCount,
-            final LocalDateTime expiredAt, final String imageDescription, final List<Image> images) {
+            final LocalDateTime expiredAt, final String imageDescription, final List<Image> images,
+            final Image image) {
         this.groupId = groupId;
         this.badgeId = badgeId;
         this.interestName = interestName;
@@ -106,22 +111,23 @@ public class Quest {
         this.state = NEED_LABEL;
         this.imageDescription = imageDescription;
         this.images = images;
+        this.image = image;
         validate();
     }
 
     public static Quest createNormalQuest(final Long badgeId, final String interestName, final String title,
             final String content, final Long rewardCount, final String imageDescription,
-            final List<Image> images) {
+            final List<Image> images, final Image image) {
         return new Quest(null, badgeId, interestName, title, content, QuestCategory.NORMAL, rewardCount
-                , null, imageDescription, images);
+                , null, imageDescription, images, image);
     }
 
     public static Quest createGroupQuest(final Long groupId, final String interestName, final String title,
             final String content, final LocalDateTime expiredAt, final String imageDescription,
-            final List<Image> images) {
+            final List<Image> images, final Image image) {
         validateGroupId(groupId);
         return new Quest(groupId, null, interestName, title, content, QuestCategory.GROUP, null
-                , expiredAt, imageDescription, images);
+                , expiredAt, imageDescription, images, image);
     }
 
     private static void validateGroupId(final Long groupId) {
@@ -169,7 +175,7 @@ public class Quest {
 
     private void validateImageCount() {
         if (images.size() != IMAGE_COUNT) {
-            throw new InvalidDomainException(INVALID_QUEST_IMAGE);
+            throw new InvalidDomainException(INVALID_QUEST_IMAGES);
         }
     }
 

--- a/src/main/java/daybyquest/quest/domain/QuestRepository.java
+++ b/src/main/java/daybyquest/quest/domain/QuestRepository.java
@@ -10,4 +10,6 @@ interface QuestRepository extends Repository<Quest, Long> {
     Optional<Quest> findById(final Long id);
 
     boolean existsById(final Long id);
+
+    boolean existsByBadgeId(final Long badgeId);
 }

--- a/src/main/java/daybyquest/quest/domain/Quests.java
+++ b/src/main/java/daybyquest/quest/domain/Quests.java
@@ -1,6 +1,9 @@
 package daybyquest.quest.domain;
 
+import static daybyquest.global.error.ExceptionCode.ALREADY_EXIST_REWARD;
+
 import daybyquest.badge.domain.Badges;
+import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.global.error.exception.NotExistQuestException;
 import org.springframework.stereotype.Component;
 
@@ -19,11 +22,18 @@ public class Quests {
     public Long save(final Quest quest) {
         if (quest.getBadgeId() != null) {
             badges.validateExistentById(quest.getBadgeId());
+            validateNotExistentByBadgeId(quest.getBadgeId());
         }
         return questRepository.save(quest).getId();
     }
 
     public Quest getById(final Long id) {
         return questRepository.findById(id).orElseThrow(NotExistQuestException::new);
+    }
+
+    private void validateNotExistentByBadgeId(final Long badgeId) {
+        if (questRepository.existsByBadgeId(badgeId)) {
+            throw new InvalidDomainException(ALREADY_EXIST_REWARD);
+        }
     }
 }

--- a/src/main/java/daybyquest/quest/dto/response/MultipleQuestsResponse.java
+++ b/src/main/java/daybyquest/quest/dto/response/MultipleQuestsResponse.java
@@ -1,0 +1,7 @@
+package daybyquest.quest.dto.response;
+
+import java.util.List;
+
+public record MultipleQuestsResponse(List<QuestResponse> quests) {
+
+}

--- a/src/main/java/daybyquest/quest/query/QuestDao.java
+++ b/src/main/java/daybyquest/quest/query/QuestDao.java
@@ -1,6 +1,11 @@
 package daybyquest.quest.query;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface QuestDao {
 
     QuestData getById(final Long userId, final Long id);
+
+    List<QuestData> findAllByIdIn(final Long userId, final Collection<Long> ids);
 }

--- a/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
@@ -64,54 +64,8 @@ public class QuestDaoQuerydslImpl implements QuestDao {
     public List<QuestData> findAllByIdIn(final Long userId, final Collection<Long> ids) {
         return factory.select(projectQuestData(userId, quest.id))
                 .from(quest)
-                .where(quest.id.eq(id))
-                .fetchOne();
-        if (data == null) {
-            throw new NotExistQuestException();
-        }
-
-        setParticipantState(data, userId, id);
-        setDetail(data);
-        return data;
-    }
-
-    private void setParticipantState(final QuestData data, final Long userId, final Long id) {
-        ParticipantState state = factory.select(participant.state)
-                .from(participant)
-                .where(participant.userId.eq(userId), participant.quest.id.eq(id))
-                .fetchOne();
-        if (state == null) {
-            state = ParticipantState.NOT;
-        }
-        data.setState(state);
-    }
-
-    private void setDetail(final QuestData data) {
-        if (data.isGroupQuest()) {
-            setGroupDetail(data);
-            return;
-        }
-        setNormalDetail(data);
-    }
-
-    private void setNormalDetail(final QuestData data) {
-        if (data.getBadgeId() == null) {
-            return;
-        }
-        final Badge questBadge = factory.selectFrom(badge)
-                .where(badge.id.eq(data.getBadgeId()))
-                .fetchOne();
-        if (questBadge != null) {
-            data.setNormalDetail(questBadge);
-        }
-    }
-
-    private void setGroupDetail(final QuestData data) {
-        final Group questGroup = factory.selectFrom(group)
-                .where(group.id.eq(data.getGroupId()))
-                .fetchOne();
-        if (questGroup != null) {
-            data.setGroupDetail(questGroup);
-        }
+                .leftJoin(group).on(group.id.eq(quest.groupId))
+                .where(quest.id.in(ids))
+                .fetch();
     }
 }

--- a/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
@@ -1,19 +1,19 @@
 package daybyquest.quest.query;
 
-import static daybyquest.badge.domain.QBadge.badge;
 import static daybyquest.group.domain.QGroup.group;
 import static daybyquest.participant.domain.QParticipant.participant;
 import static daybyquest.post.domain.PostState.SUCCESS;
 import static daybyquest.post.domain.QPost.post;
 import static daybyquest.quest.domain.QQuest.quest;
 
+import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import daybyquest.badge.domain.Badge;
 import daybyquest.global.error.exception.NotExistQuestException;
-import daybyquest.group.domain.Group;
-import daybyquest.participant.domain.ParticipantState;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,20 +27,42 @@ public class QuestDaoQuerydslImpl implements QuestDao {
 
     @Override
     public QuestData getById(final Long userId, final Long id) {
-        final QuestData data = factory.select(Projections.constructor(QuestData.class,
-                        quest.id,
-                        quest.groupId,
-                        quest.badgeId,
-                        quest.title,
-                        quest.content,
-                        quest.interestName,
-                        quest.category,
-                        quest.expiredAt,
-                        quest.rewardCount,
-                        JPAExpressions.select(post.count())
-                                .from(post)
-                                .where(post.userId.eq(userId), post.questId.eq(id), post.state.eq(SUCCESS))
-                ))
+        final QuestData data = factory.select(projectQuestData(userId, quest.id))
+                .from(quest)
+                .leftJoin(group).on(group.id.eq(quest.groupId))
+                .where(quest.id.eq(id))
+                .fetchOne();
+        if (data == null) {
+            throw new NotExistQuestException();
+        }
+        return data;
+    }
+
+    private ConstructorExpression<QuestData> projectQuestData(final Long userId, final NumberPath<Long> id) {
+        return Projections.constructor(QuestData.class,
+                quest.id,
+                quest.groupId,
+                quest.badgeId,
+                quest.title,
+                quest.content,
+                quest.interestName,
+                quest.category,
+                JPAExpressions.select(participant.state)
+                        .from(participant)
+                        .where(participant.userId.eq(userId), participant.quest.id.eq(id)),
+                quest.expiredAt,
+                quest.image,
+                quest.rewardCount,
+                JPAExpressions.select(post.count())
+                        .from(post)
+                        .where(post.userId.eq(userId), post.questId.eq(id), post.state.eq(SUCCESS)),
+                group.name
+        );
+    }
+
+    @Override
+    public List<QuestData> findAllByIdIn(final Long userId, final Collection<Long> ids) {
+        return factory.select(projectQuestData(userId, quest.id))
                 .from(quest)
                 .where(quest.id.eq(id))
                 .fetchOne();

--- a/src/main/java/daybyquest/quest/query/QuestData.java
+++ b/src/main/java/daybyquest/quest/query/QuestData.java
@@ -39,7 +39,8 @@ public class QuestData {
 
     public QuestData(final Long id, final Long groupId, final Long badgeId, final String title,
             final String content, final String interestName, final QuestCategory category,
-            final LocalDateTime expiredAt, final Long rewardCount, final Long currentCount) {
+            final ParticipantState state, final LocalDateTime expiredAt, final Image image,
+            final Long rewardCount, final Long currentCount, final String groupName) {
         this.id = id;
         this.groupId = groupId;
         this.badgeId = badgeId;
@@ -48,8 +49,15 @@ public class QuestData {
         this.interestName = interestName;
         this.category = category;
         this.expiredAt = expiredAt;
+        this.image = image;
         this.rewardCount = rewardCount;
         this.currentCount = currentCount;
+        this.groupName = groupName;
+        if (state == null) {
+            this.state = ParticipantState.NOT;
+            return;
+        }
+        this.state = state;
     }
 
     public String getImageIdentifier() {

--- a/src/main/resources/db/migration/V3__rename_profile_setting.sql
+++ b/src/main/resources/db/migration/V3__rename_profile_setting.sql
@@ -1,2 +1,2 @@
 ALTER TABLE `profile_setting`
-    RENAME COLUMN `badge_list` TO `badge_ids`
+    RENAME COLUMN `badge_list` TO `badge_ids`;

--- a/src/main/resources/db/migration/V4__quest_image.sql
+++ b/src/main/resources/db/migration/V4__quest_image.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `quest`
+    ADD `identifier` varchar(255) not null;

--- a/src/main/resources/db/migration/V5__modify_quest_image.sql
+++ b/src/main/resources/db/migration/V5__modify_quest_image.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `quest`
+    MODIFY COLUMN `identifier` varchar(255);

--- a/src/test/java/daybyquest/participant/query/ParticipantDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/participant/query/ParticipantDaoQuerydslImplTest.java
@@ -1,0 +1,100 @@
+package daybyquest.participant.query;
+
+import static daybyquest.participant.domain.ParticipantState.CONTINUE;
+import static daybyquest.participant.domain.ParticipantState.DOING;
+import static daybyquest.participant.domain.ParticipantState.FINISHED;
+import static daybyquest.support.fixture.QuestFixtures.QUEST_1;
+import static daybyquest.support.fixture.QuestFixtures.QUEST_2;
+import static daybyquest.support.util.ParticipantUtils.퀘스트를_계속한다;
+import static daybyquest.support.util.ParticipantUtils.퀘스트를_끝낸다;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import daybyquest.participant.domain.Participant;
+import daybyquest.quest.domain.Quest;
+import daybyquest.support.test.QuerydslTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+@Import(ParticipantDaoQuerydslImpl.class)
+public class ParticipantDaoQuerydslImplTest extends QuerydslTest {
+
+    @Autowired
+    private ParticipantDaoQuerydslImpl participantDao;
+
+    @Test
+    void 진행중인_퀘스트_ID들을_조회한다() {
+        // given
+        final Long userId = 1L;
+
+        final Quest 진행중인_퀘스트_1 = 저장한다(QUEST_1.일반_퀘스트_생성());
+        final Quest 끝난_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 계속하는_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 진행중인_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
+
+        저장한다(new Participant(userId, 진행중인_퀘스트_1));
+        퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트)));
+        퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트)));
+        저장한다(new Participant(userId, 진행중인_퀘스트_2));
+        저장한다(QUEST_1.일반_퀘스트_생성());
+
+        final List<Long> expected = List.of(진행중인_퀘스트_1.getId(), 진행중인_퀘스트_2.getId());
+
+        // when
+        final List<Long> actual = participantDao.findIdsByUserIdAndState(userId, DOING);
+
+        // then
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void 계속하는_퀘스트_ID들을_조회한다() {
+        // given
+        final Long userId = 1L;
+
+        final Quest 계속하는_퀘스트_1 = 저장한다(QUEST_1.일반_퀘스트_생성());
+        final Quest 계속하는_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 끝난_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 진행중인_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+
+        퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트_1)));
+        퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트_2)));
+        퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트)));
+        저장한다(new Participant(userId, 진행중인_퀘스트));
+        저장한다(QUEST_1.일반_퀘스트_생성());
+
+        final List<Long> expected = List.of(계속하는_퀘스트_1.getId(), 계속하는_퀘스트_2.getId());
+
+        // when
+        final List<Long> actual = participantDao.findIdsByUserIdAndState(userId, CONTINUE);
+
+        // then
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+
+    @Test
+    void 끝난_퀘스트_ID들을_조회한다() {
+        // given
+        final Long userId = 1L;
+
+        final Quest 끝난_퀘스트_1 = 저장한다(QUEST_1.일반_퀘스트_생성());
+        final Quest 끝난_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 계속하는_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        final Quest 진행_중인_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        
+        퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트_1)));
+        퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트_2)));
+        퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트)));
+        저장한다(new Participant(userId, 진행_중인_퀘스트));
+        저장한다(QUEST_1.일반_퀘스트_생성());
+
+        final List<Long> expected = List.of(끝난_퀘스트_1.getId(), 끝난_퀘스트_2.getId());
+
+        // when
+        final List<Long> actual = participantDao.findIdsByUserIdAndState(userId, FINISHED);
+
+        // then
+        assertThat(actual).containsExactlyElementsOf(expected);
+    }
+}

--- a/src/test/java/daybyquest/quest/domain/QuestTest.java
+++ b/src/test/java/daybyquest/quest/domain/QuestTest.java
@@ -28,7 +28,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -39,7 +39,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -50,7 +50,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -61,7 +61,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -72,7 +72,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -81,7 +81,7 @@ public class QuestTest {
         void 목표치가_1보다_작으면_예외를_던진다(final Long rewardCount) {
             // given & when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -90,7 +90,7 @@ public class QuestTest {
         void 목표치가_365보다_크면_예외를_던진다(final Long rewardCount) {
             // given & when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -102,7 +102,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images))
+                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -113,7 +113,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images))
+                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -121,7 +121,7 @@ public class QuestTest {
         void 보상이_없는데_목표치가_있으면_예외를_던진다() {
             // given & when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, 1L, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, 1L, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -129,7 +129,7 @@ public class QuestTest {
         void 보상이_있는데_목표치가_없으면_예외를_던진다() {
             // given & when & then
             assertThatThrownBy(() -> Quest.createNormalQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
     }
@@ -141,7 +141,7 @@ public class QuestTest {
         void 그룹_ID가_없으면_예외를_던진다() {
             // given & when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -152,7 +152,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -163,7 +163,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -174,7 +174,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -185,7 +185,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -196,7 +196,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -208,7 +208,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images))
+                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -219,7 +219,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images))
+                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
 
@@ -230,7 +230,7 @@ public class QuestTest {
 
             // when & then
             assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, expiredAt, QUEST_1.imageDescription, QUEST_1.사진_목록()))
+                    QUEST_1.content, expiredAt, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
                     .isInstanceOf(InvalidDomainException.class);
         }
     }

--- a/src/test/java/daybyquest/quest/domain/QuestsTest.java
+++ b/src/test/java/daybyquest/quest/domain/QuestsTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import daybyquest.badge.domain.Badges;
+import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.global.error.exception.NotExistQuestException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ public class QuestsTest {
         // then
         assertAll(() -> {
             then(badges).should().validateExistentById(badgeId);
+            then(questRepository).should().existsByBadgeId(badgeId);
             then(questRepository).should().save(any(Quest.class));
         });
     }
@@ -57,6 +59,17 @@ public class QuestsTest {
 
         // then
         then(questRepository).should().save(any(Quest.class));
+    }
+
+    @Test
+    void 동일한_뱃지가_보상인_퀘스트가_이미_있다면_예외를_던진다() {
+        // given
+        final Long badgeId = 1L;
+        given(questRepository.existsByBadgeId(badgeId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> quests.save(QUEST_1.일반_퀘스트_생성(badgeId)))
+                .isInstanceOf(InvalidDomainException.class);
     }
 
     @Test

--- a/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
@@ -12,6 +12,8 @@ import static daybyquest.support.fixture.PostFixtures.POST_1;
 import static daybyquest.support.fixture.PostFixtures.POST_2;
 import static daybyquest.support.fixture.PostFixtures.POST_3;
 import static daybyquest.support.fixture.QuestFixtures.QUEST_1;
+import static daybyquest.support.fixture.QuestFixtures.QUEST_2;
+import static daybyquest.support.fixture.QuestFixtures.QUEST_3;
 import static daybyquest.support.fixture.UserFixtures.ALICE;
 import static daybyquest.support.fixture.UserFixtures.BOB;
 import static daybyquest.support.fixture.UserFixtures.CHARLIE;
@@ -29,6 +31,7 @@ import daybyquest.participant.domain.Participant;
 import daybyquest.quest.domain.Quest;
 import daybyquest.support.test.QuerydslTest;
 import daybyquest.user.domain.User;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -109,6 +112,7 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         assertAll(() -> {
             assertThat(questData.getGroupId()).isEqualTo(group.getId());
             assertThat(questData.getImage()).isEqualTo(group.getImage());
+            assertThat(questData.getGroupName()).isEqualTo(group.getName());
         });
     }
 
@@ -161,5 +165,28 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         // given & when & then
         assertThatThrownBy(() -> questDao.getById(1L, 2L))
                 .isInstanceOf(NotExistQuestException.class);
+    }
+
+    @Test
+    void 컬렉션으로_퀘스트를_조회한다() {
+        // given
+        final Long userId = 1L;
+        final Badge badge = 저장한다(BADGE_1.생성());
+        final Group group = 저장한다(GROUP_1.생성());
+        final Quest quest1 = 저장한다(QUEST_1.일반_퀘스트_생성());
+        final Quest quest2 = 저장한다(QUEST_2.일반_퀘스트_생성(badge));
+        final Quest quest3 = 저장한다(QUEST_3.그룹_퀘스트_생성(group));
+        final Quest quest4 = 저장한다(QUEST_1.일반_퀘스트_생성());
+        final List<Long> expected = List.of(quest1.getId(), quest2.getId(), quest3.getId());
+
+        // when
+        final List<QuestData> questData = questDao.findAllByIdIn(userId, expected);
+        final List<Long> actual = questData.stream().map(QuestData::getId).toList();
+
+        // then
+        assertAll(() -> {
+            assertThat(questData).hasSize(3);
+            assertThat(actual).containsExactlyElementsOf(expected);
+        });
     }
 }

--- a/src/test/java/daybyquest/support/fixture/QuestFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/QuestFixtures.java
@@ -10,13 +10,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public enum QuestFixtures {
     QUEST_1("일반퀘스트1", "퀘스트1입니다", "관심사", 5L, null,
-            "퀘스트1 사진 설명입니다", List.of("퀘스트사진1_1", "퀘스트사진1_2", "퀘스트사진1_3"), "라벨1"),
+            "퀘스트1 사진 설명입니다", List.of("퀘스트사진1_1", "퀘스트사진1_2", "퀘스트사진1_3"), "라벨1", "퀘스트사진1"),
     QUEST_2("일반퀘스트2", "퀘스트2입니다", "관심사", 10L, null,
-            "퀘스트2 사진 설명입니다", List.of("퀘스트사진2_1", "퀘스트사진2_2", "퀘스트사진2_3"), "라벨2"),
+            "퀘스트2 사진 설명입니다", List.of("퀘스트사진2_1", "퀘스트사진2_2", "퀘스트사진2_3"), "라벨2", "퀘스트사진2"),
     QUEST_3("일반퀘스트3", "퀘스트3입니다", "관심사", 15L, null,
-            "퀘스트3 사진 설명입니다", List.of("퀘스트사진3_1", "퀘스트사진3_2", "퀘스트사진3_3"), "라벨3"),
+            "퀘스트3 사진 설명입니다", List.of("퀘스트사진3_1", "퀘스트사진3_2", "퀘스트사진3_3"), "라벨3", "퀘스트사진3"),
     QUEST_WITHOUT_REWARD("일반퀘스트", "퀘스트입니다", "관심사", null, null,
-            "퀘스트 사진 설명입니다", List.of("퀘스트사진_1", "퀘스트사진_2", "퀘스트사진_3"), "라벨4");
+            "퀘스트 사진 설명입니다", List.of("퀘스트사진_1", "퀘스트사진_2", "퀘스트사진_3"), "라벨4", "퀘스트사진4");
 
     public final String title;
 
@@ -34,9 +34,11 @@ public enum QuestFixtures {
 
     public final String label;
 
+    public final String imageIdentifier;
+
     QuestFixtures(final String title, final String content, final String interest,
-            final Long rewardCount, final LocalDateTime expiredAt,
-            final String imageDescription, final List<String> imageIdentifiers, final String label) {
+            final Long rewardCount, final LocalDateTime expiredAt, final String imageDescription,
+            final List<String> imageIdentifiers, final String label, final String imageIdentifier) {
         this.title = title;
         this.content = content;
         this.interest = interest;
@@ -45,6 +47,7 @@ public enum QuestFixtures {
         this.imageDescription = imageDescription;
         this.imageIdentifiers = imageIdentifiers;
         this.label = label;
+        this.imageIdentifier = imageIdentifier;
     }
 
     public Quest 일반_퀘스트_생성(final Long id, final Long badgeId) {
@@ -53,7 +56,7 @@ public enum QuestFixtures {
             rewardCount = null;
         }
         final Quest quest = Quest.createNormalQuest(badgeId, interest, title, content, rewardCount,
-                imageDescription, 사진_목록());
+                imageDescription, 사진_목록(), 사진());
         ReflectionTestUtils.setField(quest, "id", id);
         return quest;
     }
@@ -67,12 +70,13 @@ public enum QuestFixtures {
     }
 
     public Quest 일반_퀘스트_생성(final Badge badge) {
-        return 일반_퀘스트_생성(badge.getId());
+        return Quest.createNormalQuest(badge.getId(), interest, title, content, rewardCount,
+                imageDescription, 사진_목록(), badge.getImage());
     }
 
     public Quest 그룹_퀘스트_생성(final Long id, final Long groupId) {
         final Quest quest = Quest.createGroupQuest(groupId, interest, title, content, expiredAt,
-                imageDescription, 사진_목록());
+                imageDescription, 사진_목록(), 사진());
         ReflectionTestUtils.setField(quest, "id", id);
         return quest;
     }
@@ -82,10 +86,15 @@ public enum QuestFixtures {
     }
 
     public Quest 그룹_퀘스트_생성(final Group group) {
-        return 그룹_퀘스트_생성(group.getId());
+        return Quest.createGroupQuest(group.getId(), interest, title, content, expiredAt,
+                imageDescription, 사진_목록(), group.getImage());
     }
 
     public List<Image> 사진_목록() {
         return imageIdentifiers.stream().map(Image::new).toList();
+    }
+
+    public Image 사진() {
+        return new Image(imageIdentifier);
     }
 }


### PR DESCRIPTION
## 🗒️ Summary
### 리팩토링
- 이제 퀘스트 도메인 객체가 대표 사진을 갖도록 변경함
  - 뱃지, 그룹 대표 사진들을 차용하여 설정할 수 있음. 일종의 반정규화로 쿼리를 개선하기 위해 추가함
- 퀘스트 생성 시 뱃지가 이미 보상으로 주어진적 있는지 검증한다

>#58 

## 💡 More
- 