### PR TITLE
[Feature] 퀘스트 생성 과정을 리팩토링하고 그룹 퀘스트 생성을 구현한다

### DIFF
--- a/src/main/java/daybyquest/global/error/ExceptionCode.java
+++ b/src/main/java/daybyquest/global/error/ExceptionCode.java
@@ -79,6 +79,7 @@ public enum ExceptionCode {
     INVALID_GROUP_NAME("GRP-07", BAD_REQUEST, "그룹 이름은 1~15자여야 합니다"),
     INVALID_GROUP_DESCRIPTION("GRP-08", BAD_REQUEST, "그룹 설명은 200자 이하여야 합니다"),
     NOT_DELETABLE_GROUP_USER("GRP-09", BAD_REQUEST, "매니저는 탈퇴할 수 없습니다"),
+    NOT_GROUP_MANAGER("GRP-10", BAD_REQUEST, "그룹 매니저만 가능한 권한입니다"),
 
     // Badge
     NOT_EXIST_BADGE("BDE-00", BAD_REQUEST, "존재하지 않는 뱃지입니다"),

--- a/src/main/java/daybyquest/global/error/ExceptionCode.java
+++ b/src/main/java/daybyquest/global/error/ExceptionCode.java
@@ -67,6 +67,7 @@ public enum ExceptionCode {
     ALREADY_LABELED("QUE-16", BAD_REQUEST, "이미 라벨링된 퀘스트입니다"),
     INVALID_QUEST_IMAGE("QUE-17", BAD_REQUEST, "퀘스트 사진이 없습니다"),
     ALREADY_EXIST_REWARD("QUE-18", BAD_REQUEST, "이미 보상으로 설정된 뱃지입니다"),
+    CANNOT_PARTICIPATE("QUE-19", BAD_REQUEST, "수락할 수 없는 퀘스트입니다"),
 
     // Group
     NOT_EXIST_GROUP("GRP-00", BAD_REQUEST, "존재하지 않는 그룹입니다"),

--- a/src/main/java/daybyquest/group/domain/GroupUsers.java
+++ b/src/main/java/daybyquest/group/domain/GroupUsers.java
@@ -16,6 +16,12 @@ public class GroupUsers {
         this.groupUserRepository = groupUserRepository;
     }
 
+    public void validateExistentByUserIdAndGroupId(final Long userId, final Long groupId) {
+        if (!groupUserRepository.existsByUserIdAndGroupId(userId, groupId)) {
+            throw new NotExistGroupUserException();
+        }
+    }
+
     public GroupUser getByUserIdAndGroupId(final Long userId, final Long groupId) {
         return groupUserRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(NotExistGroupUserException::new);

--- a/src/main/java/daybyquest/group/domain/GroupUsers.java
+++ b/src/main/java/daybyquest/group/domain/GroupUsers.java
@@ -1,6 +1,7 @@
 package daybyquest.group.domain;
 
 import static daybyquest.global.error.ExceptionCode.NOT_DELETABLE_GROUP_USER;
+import static daybyquest.global.error.ExceptionCode.NOT_GROUP_MANAGER;
 
 import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.global.error.exception.NotExistGroupUserException;
@@ -18,6 +19,13 @@ public class GroupUsers {
     public GroupUser getByUserIdAndGroupId(final Long userId, final Long groupId) {
         return groupUserRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(NotExistGroupUserException::new);
+    }
+
+    public void validateGroupManager(final Long userId, final Long groupId) {
+        final GroupUser groupUser = getByUserIdAndGroupId(userId, groupId);
+        if (!groupUser.isManager()) {
+            throw new InvalidDomainException(NOT_GROUP_MANAGER);
+        }
     }
 
     public void delete(final GroupUser groupUser) {

--- a/src/main/java/daybyquest/participant/domain/Participant.java
+++ b/src/main/java/daybyquest/participant/domain/Participant.java
@@ -45,6 +45,7 @@ public class Participant {
         this.quest = quest;
         this.state = DOING;
         this.linkedCount = 0L;
+        quest.validateCanParticipate();
     }
 
     public Long getQuestId() {

--- a/src/main/java/daybyquest/participant/domain/Participants.java
+++ b/src/main/java/daybyquest/participant/domain/Participants.java
@@ -28,6 +28,7 @@ public class Participants {
     public void saveWithUserIdAndQuestId(final Long userId, final Long questId) {
         users.validateExistentById(userId);
         final Quest quest = quests.getById(questId);
+        quest.validateCanParticipate();
         final Participant participant = new Participant(userId, quest);
         validateNotExistent(participant);
         participantRepository.save(participant);

--- a/src/main/java/daybyquest/participant/domain/Participants.java
+++ b/src/main/java/daybyquest/participant/domain/Participants.java
@@ -4,6 +4,7 @@ import static daybyquest.global.error.ExceptionCode.ALREADY_ACCEPTED_QUEST;
 import static daybyquest.global.error.ExceptionCode.NOT_ACCEPTED_QUEST;
 
 import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.group.domain.GroupUsers;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
 import daybyquest.user.domain.Users;
@@ -18,20 +19,30 @@ public class Participants {
 
     private final Quests quests;
 
+    private final GroupUsers groupUsers;
+
     Participants(final ParticipantRepository participantRepository, final Users users,
-            final Quests quests) {
+            final Quests quests, final GroupUsers groupUsers) {
         this.participantRepository = participantRepository;
         this.users = users;
         this.quests = quests;
+        this.groupUsers = groupUsers;
     }
 
     public void saveWithUserIdAndQuestId(final Long userId, final Long questId) {
         users.validateExistentById(userId);
         final Quest quest = quests.getById(questId);
         quest.validateCanParticipate();
+        validateGroupQuest(userId, quest);
         final Participant participant = new Participant(userId, quest);
         validateNotExistent(participant);
         participantRepository.save(participant);
+    }
+
+    private void validateGroupQuest(final Long userId, final Quest quest) {
+        if (quest.isGroupQuest()) {
+            groupUsers.validateExistentByUserIdAndGroupId(userId, quest.getGroupId());
+        }
     }
 
     private void validateNotExistent(final Participant participant) {

--- a/src/main/java/daybyquest/participant/domain/Participants.java
+++ b/src/main/java/daybyquest/participant/domain/Participants.java
@@ -32,7 +32,6 @@ public class Participants {
     public void saveWithUserIdAndQuestId(final Long userId, final Long questId) {
         users.validateExistentById(userId);
         final Quest quest = quests.getById(questId);
-        quest.validateCanParticipate();
         validateGroupQuest(userId, quest);
         final Participant participant = new Participant(userId, quest);
         validateNotExistent(participant);

--- a/src/main/java/daybyquest/quest/application/SaveGroupQuestDetailService.java
+++ b/src/main/java/daybyquest/quest/application/SaveGroupQuestDetailService.java
@@ -1,0 +1,29 @@
+package daybyquest.quest.application;
+
+import daybyquest.group.domain.GroupUsers;
+import daybyquest.quest.domain.Quest;
+import daybyquest.quest.domain.Quests;
+import daybyquest.quest.dto.request.SaveGroupQuestDetailRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SaveGroupQuestDetailService {
+
+    private final Quests quests;
+
+    private final GroupUsers groupUsers;
+
+    public SaveGroupQuestDetailService(final Quests quests, final GroupUsers groupUsers) {
+        this.quests = quests;
+        this.groupUsers = groupUsers;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long questId, final SaveGroupQuestDetailRequest request) {
+        final Quest quest = quests.getById(questId);
+        groupUsers.validateGroupManager(loginId, quest.getGroupId());
+        quest.setDetail(request.getTitle(), request.getContent(), request.getInterest(),
+                request.getExpiredAt(), request.getLabel(), null);
+    }
+}

--- a/src/main/java/daybyquest/quest/application/SaveGroupQuestService.java
+++ b/src/main/java/daybyquest/quest/application/SaveGroupQuestService.java
@@ -1,27 +1,30 @@
 package daybyquest.quest.application;
 
-import daybyquest.badge.domain.Badge;
-import daybyquest.badge.domain.Badges;
 import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.group.domain.Group;
+import daybyquest.group.domain.GroupUsers;
+import daybyquest.group.domain.Groups;
 import daybyquest.image.domain.Image;
 import daybyquest.image.domain.ImageIdentifierGenerator;
 import daybyquest.image.domain.Images;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
-import daybyquest.quest.dto.request.SaveQuestRequest;
+import daybyquest.quest.dto.request.SaveGroupQuestRequest;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-public class SaveQuestService {
+public class SaveGroupQuestService {
 
     private static final String CATEGORY = "QUEST";
 
     private final Quests quests;
 
-    private final Badges badges;
+    private final Groups groups;
+
+    private final GroupUsers groupUsers;
 
     private final Images images;
 
@@ -29,17 +32,21 @@ public class SaveQuestService {
 
     private final QuestClient questClient;
 
-    public SaveQuestService(final Quests quests, final Badges badges, final Images images,
+    public SaveGroupQuestService(final Quests quests, final Groups groups, final GroupUsers groupUsers,
+            final Images images,
             final ImageIdentifierGenerator generator, final QuestClient questClient) {
         this.quests = quests;
-        this.badges = badges;
+        this.groups = groups;
+        this.groupUsers = groupUsers;
         this.images = images;
         this.generator = generator;
         this.questClient = questClient;
     }
 
     @Transactional
-    public Long invoke(final SaveQuestRequest request, final List<MultipartFile> files) {
+    public Long invoke(final Long loginId, final SaveGroupQuestRequest request,
+            final List<MultipartFile> files) {
+        groupUsers.validateGroupManager(loginId, request.getGroupId());
         final Quest quest = toEntity(request, toImageList(files));
         final Long questId = quests.save(quest);
         questClient.requestLabels(questId, quest.getImages().stream().map(Image::getIdentifier).toList());
@@ -53,9 +60,9 @@ public class SaveQuestService {
         }).toList();
     }
 
-    private Quest toEntity(final SaveQuestRequest request, final List<Image> images) {
-        final Badge badge = badges.getById(request.getBadgeId());
-        return Quest.createNormalQuest(badge.getId(), request.getImageDescription(), images,
-                badge.getImage());
+    private Quest toEntity(final SaveGroupQuestRequest request, final List<Image> images) {
+        final Group group = groups.getById(request.getGroupId());
+        return Quest.createGroupQuest(group.getId(), request.getImageDescription(), images,
+                group.getImage());
     }
 }

--- a/src/main/java/daybyquest/quest/application/SaveQuestDetailService.java
+++ b/src/main/java/daybyquest/quest/application/SaveQuestDetailService.java
@@ -1,0 +1,24 @@
+package daybyquest.quest.application;
+
+import daybyquest.quest.domain.Quest;
+import daybyquest.quest.domain.Quests;
+import daybyquest.quest.dto.request.SaveQuestDetailRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SaveQuestDetailService {
+
+    private final Quests quests;
+
+    public SaveQuestDetailService(final Quests quests) {
+        this.quests = quests;
+    }
+
+    @Transactional
+    public void invoke(final Long questId, final SaveQuestDetailRequest request) {
+        final Quest quest = quests.getById(questId);
+        quest.setDetail(request.getTitle(), request.getContent(), request.getInterest(),
+                null, request.getLabel(), request.getRewardCount());
+    }
+}

--- a/src/main/java/daybyquest/quest/domain/Quest.java
+++ b/src/main/java/daybyquest/quest/domain/Quest.java
@@ -204,4 +204,8 @@ public class Quest {
             throw new InvalidDomainException(CANNOT_PARTICIPATE);
         }
     }
+
+    public boolean isGroupQuest() {
+        return category == GROUP;
+    }
 }

--- a/src/main/java/daybyquest/quest/domain/Quest.java
+++ b/src/main/java/daybyquest/quest/domain/Quest.java
@@ -10,6 +10,8 @@ import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_NAME;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_REWARD;
 import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_REWARD_COUNT;
 import static daybyquest.global.error.ExceptionCode.NOT_EXIST_GROUP;
+import static daybyquest.quest.domain.QuestCategory.GROUP;
+import static daybyquest.quest.domain.QuestCategory.NORMAL;
 import static daybyquest.quest.domain.QuestState.ACTIVE;
 import static daybyquest.quest.domain.QuestState.NEED_LABEL;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -112,13 +114,13 @@ public class Quest {
 
     public static Quest createNormalQuest(final Long badgeId, final String imageDescription,
             final List<Image> images, final Image image) {
-        return new Quest(null, badgeId, QuestCategory.GROUP, imageDescription, images, image);
+        return new Quest(null, badgeId, NORMAL, imageDescription, images, image);
     }
 
     public static Quest createGroupQuest(final Long groupId, final String imageDescription,
             final List<Image> images, final Image image) {
         validateGroupId(groupId);
-        return new Quest(groupId, null, QuestCategory.GROUP, imageDescription, images, image);
+        return new Quest(groupId, null, GROUP, imageDescription, images, image);
     }
 
     private static void validateGroupId(final Long groupId) {

--- a/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestDetailRequest.java
+++ b/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestDetailRequest.java
@@ -1,0 +1,27 @@
+package daybyquest.quest.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SaveGroupQuestDetailRequest {
+
+    @NotBlank
+    private String title;
+
+    private String content;
+
+    @NotBlank
+    private String interest;
+
+    @NotBlank
+    private String label;
+
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestRequest.java
+++ b/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestRequest.java
@@ -1,5 +1,6 @@
 package daybyquest.quest.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class SaveGroupQuestRequest {
 
+    @NotBlank
     private Long groupId;
 
+    @NotBlank
     private String imageDescription;
 }

--- a/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestRequest.java
+++ b/src/main/java/daybyquest/quest/dto/request/SaveGroupQuestRequest.java
@@ -5,9 +5,9 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class SaveQuestRequest {
+public class SaveGroupQuestRequest {
 
-    private Long badgeId;
+    private Long groupId;
 
     private String imageDescription;
 }

--- a/src/main/java/daybyquest/quest/dto/request/SaveQuestDetailRequest.java
+++ b/src/main/java/daybyquest/quest/dto/request/SaveQuestDetailRequest.java
@@ -1,0 +1,23 @@
+package daybyquest.quest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SaveQuestDetailRequest {
+
+    @NotBlank
+    private String title;
+
+    private String content;
+
+    @NotBlank
+    private String interest;
+
+    @NotBlank
+    private String label;
+
+    private Long rewardCount;
+}

--- a/src/main/java/daybyquest/quest/dto/request/SaveQuestRequest.java
+++ b/src/main/java/daybyquest/quest/dto/request/SaveQuestRequest.java
@@ -1,5 +1,6 @@
 package daybyquest.quest.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class SaveQuestRequest {
 
+    @NotBlank
     private Long badgeId;
 
+    @NotBlank
     private String imageDescription;
 }

--- a/src/main/java/daybyquest/quest/dto/response/SaveQuestResponse.java
+++ b/src/main/java/daybyquest/quest/dto/response/SaveQuestResponse.java
@@ -1,0 +1,5 @@
+package daybyquest.quest.dto.response;
+
+public record SaveQuestResponse(Long questId) {
+
+}

--- a/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
+++ b/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
@@ -2,13 +2,21 @@ package daybyquest.quest.presentation;
 
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
-import daybyquest.quest.application.GetQuestByIdService;
+import daybyquest.quest.application.SaveGroupQuestDetailService;
+import daybyquest.quest.application.SaveGroupQuestService;
+import daybyquest.quest.application.SaveQuestDetailService;
 import daybyquest.quest.application.SaveQuestService;
+import daybyquest.quest.dto.request.SaveGroupQuestDetailRequest;
+import daybyquest.quest.dto.request.SaveGroupQuestRequest;
+import daybyquest.quest.dto.request.SaveQuestDetailRequest;
 import daybyquest.quest.dto.request.SaveQuestRequest;
-import daybyquest.quest.dto.response.QuestResponse;
+import daybyquest.quest.dto.response.SaveQuestResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,21 +26,53 @@ public class QuestCommandApi {
 
     private final SaveQuestService saveQuestService;
 
-    private final GetQuestByIdService getQuestByIdService;
+    private final SaveGroupQuestService saveGroupQuestService;
+
+    private final SaveQuestDetailService saveQuestDetailService;
+
+    private final SaveGroupQuestDetailService saveGroupQuestDetailService;
 
     public QuestCommandApi(final SaveQuestService saveQuestService,
-            final GetQuestByIdService getQuestByIdService) {
+            final SaveGroupQuestService saveGroupQuestService,
+            final SaveQuestDetailService saveQuestDetailService,
+            final SaveGroupQuestDetailService saveGroupQuestDetailService) {
         this.saveQuestService = saveQuestService;
-        this.getQuestByIdService = getQuestByIdService;
+        this.saveGroupQuestService = saveGroupQuestService;
+        this.saveQuestDetailService = saveQuestDetailService;
+        this.saveGroupQuestDetailService = saveGroupQuestDetailService;
     }
 
     @PostMapping("/quest")
     @Authorization(admin = true)
-    public ResponseEntity<QuestResponse> saveQuest(final AccessUser accessUser,
+    public ResponseEntity<SaveQuestResponse> saveQuest(final AccessUser accessUser,
             @RequestPart SaveQuestRequest request,
             @RequestPart List<MultipartFile> files) {
         final Long questId = saveQuestService.invoke(request, files);
-        final QuestResponse response = getQuestByIdService.invoke(accessUser.getId(), questId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
+    }
+
+    @PostMapping("/group/quest")
+    @Authorization
+    public ResponseEntity<SaveQuestResponse> saveGroupQuest(final AccessUser accessUser,
+            @RequestPart SaveGroupQuestRequest request,
+            @RequestPart List<MultipartFile> files) {
+        final Long questId = saveGroupQuestService.invoke(accessUser.getId(), request, files);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
+    }
+
+    @PostMapping("/quest/{questId}/detail")
+    @Authorization(admin = true)
+    public ResponseEntity<SaveQuestResponse> saveQuestDetail(final AccessUser accessUser,
+            @PathVariable final Long questId, @RequestBody @Valid SaveQuestDetailRequest request) {
+        saveQuestDetailService.invoke(questId, request);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
+    }
+
+    @PostMapping("/group/{questId}/quest/detail")
+    @Authorization
+    public ResponseEntity<SaveQuestResponse> saveGroupQuestDetail(final AccessUser accessUser,
+            @PathVariable final Long questId, @RequestBody @Valid SaveGroupQuestDetailRequest request) {
+        saveGroupQuestDetailService.invoke(accessUser.getId(), questId, request);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
     }
 }

--- a/src/main/resources/db/migration/V6__modify_quest.sql
+++ b/src/main/resources/db/migration/V6__modify_quest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `quest`
+    MODIFY COLUMN `title` varchar(30);

--- a/src/test/java/daybyquest/group/domain/GroupUsersTest.java
+++ b/src/test/java/daybyquest/group/domain/GroupUsersTest.java
@@ -26,7 +26,7 @@ public class GroupUsersTest {
     private GroupUsers groupUsers;
 
     @Test
-    void 사용자_ID_와_그룹_ID_로_조회한다() {
+    void 사용자_ID와_그룹_ID로_조회한다() {
         // given
         final Long userId = 1L;
         final Long groupId = 2L;
@@ -45,7 +45,7 @@ public class GroupUsersTest {
     }
 
     @Test
-    void 사용자_ID_와_그룹_ID_로_조회_시_없다면_예외를_던진다() {
+    void 사용자_ID와_그룹_ID로_조회_시_없다면_예외를_던진다() {
         // given & when & then
         assertThatThrownBy(() -> groupUsers.getByUserIdAndGroupId(1L, 2L))
                 .isInstanceOf(NotExistGroupUserException.class);
@@ -77,5 +77,26 @@ public class GroupUsersTest {
         // when
         assertThatThrownBy(() -> groupUsers.delete(groupUser))
                 .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 사용자_ID와_그룹_ID로_그룹에_속했는지를_검증한다() {
+        // given
+        final Long userId = 1L;
+        final Long groupId = 2L;
+        given(groupUserRepository.existsByUserIdAndGroupId(userId, groupId)).willReturn(true);
+
+        // when
+        groupUsers.validateExistentByUserIdAndGroupId(userId, groupId);
+
+        // then
+        then(groupUserRepository).should().existsByUserIdAndGroupId(userId, groupId);
+    }
+
+    @Test
+    void 사용자_ID_와_그룹_ID로_그룹_가입_검증_시_없다면_예외를_던진다() {
+        // given & when & then
+        assertThatThrownBy(() -> groupUsers.validateExistentByUserIdAndGroupId(1L, 2L))
+                .isInstanceOf(NotExistGroupUserException.class);
     }
 }

--- a/src/test/java/daybyquest/participant/domain/ParticipantTest.java
+++ b/src/test/java/daybyquest/participant/domain/ParticipantTest.java
@@ -70,6 +70,7 @@ public class ParticipantTest {
         final Long badgeId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
         final Participant participant = new Participant(userId, quest);
         게시물_연결_횟수를_지정한다(participant, QUEST_1.rewardCount);
 

--- a/src/test/java/daybyquest/participant/domain/ParticipantTest.java
+++ b/src/test/java/daybyquest/participant/domain/ParticipantTest.java
@@ -25,6 +25,7 @@ public class ParticipantTest {
         final Long badgeId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
 
         // when
         final Participant participant = new Participant(userId, quest);
@@ -40,6 +41,7 @@ public class ParticipantTest {
         final Long badgeId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
 
         // when
         final Participant participant = new Participant(userId, quest);
@@ -49,12 +51,26 @@ public class ParticipantTest {
     }
 
     @Test
+    void 퀘스트_참여_시_활성화된_퀘스트가_아니라면_예외를_던진다() {
+        // given
+        final Long questId = 1L;
+        final Long badgeId = 1L;
+        final Long userId = 1L;
+        final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+
+        // when & then
+        assertThatThrownBy(() -> new Participant(userId, quest))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
     void 퀘스트_ID를_조회한다() {
         // given
         final Long questId = 1L;
         final Long badgeId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
 
         // when
         final Participant participant = new Participant(userId, quest);
@@ -91,6 +107,8 @@ public class ParticipantTest {
         final Long badgeId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(userId, quest);
         게시물_연결_횟수를_지정한다(participant, QUEST_1.rewardCount - 1);
 
@@ -105,6 +123,8 @@ public class ParticipantTest {
         final Long questId = 1L;
         final Long userId = 1L;
         final Quest quest = QUEST_WITHOUT_REWARD.일반_퀘스트_생성(questId, null);
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(userId, quest);
         게시물_연결_횟수를_지정한다(participant, QUEST_1.rewardCount);
 
@@ -122,6 +142,8 @@ public class ParticipantTest {
         final Long aliceId = 4L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant bob = new Participant(bobId, quest);
         final Participant alice = new Participant(aliceId, quest);
 
@@ -143,6 +165,8 @@ public class ParticipantTest {
         final Long bobId = 3L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(bobId, quest);
 
         퀘스트를_계속한다(participant);
@@ -163,6 +187,8 @@ public class ParticipantTest {
         final Long aliceId = 4L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant bob = new Participant(bobId, quest);
         final Participant alice = new Participant(aliceId, quest);
 
@@ -183,6 +209,8 @@ public class ParticipantTest {
         final Long bobId = 3L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(bobId, quest);
 
         퀘스트를_끝낸다(participant);
@@ -203,6 +231,8 @@ public class ParticipantTest {
         final Long aliceId = 4L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant bob = new Participant(bobId, quest);
         final Participant alice = new Participant(aliceId, quest);
 
@@ -223,6 +253,8 @@ public class ParticipantTest {
         final Long bobId = 3L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(bobId, quest);
 
         // when
@@ -240,6 +272,8 @@ public class ParticipantTest {
         final Long bobId = 3L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(bobId, quest);
         퀘스트를_계속한다(participant);
 
@@ -258,6 +292,8 @@ public class ParticipantTest {
         final Long bobId = 3L;
 
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant participant = new Participant(bobId, quest);
         퀘스트를_끝낸다(participant);
 

--- a/src/test/java/daybyquest/participant/domain/ParticipantsTest.java
+++ b/src/test/java/daybyquest/participant/domain/ParticipantsTest.java
@@ -77,22 +77,6 @@ public class ParticipantsTest {
     }
 
     @Test
-    void 참여_시_수행_불가능한_퀘스트_라면_예외를_던진다() {
-        // given
-        final Long questId = 1L;
-        final Long badgeId = 2L;
-        final Long userId = 3L;
-        final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
-        QUEST_1.세부사항을_설정한다(quest);
-        given(quests.getById(questId)).willReturn(quest);
-        given(participantRepository.existsByUserIdAndQuestId(userId, questId)).willReturn(true);
-
-        // when & then
-        assertThatThrownBy(() -> participants.saveWithUserIdAndQuestId(userId, questId))
-                .isInstanceOf(InvalidDomainException.class);
-    }
-
-    @Test
     void 참여_시_그룹_퀘스트_라면_그룹에_속했는지를_검사한다() {
         // given
         final Long questId = 1L;
@@ -141,6 +125,8 @@ public class ParticipantsTest {
         final Long badgeId = 2L;
         final Long userId = 3L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant expected = new Participant(userId, quest);
         given(participantRepository.findByUserIdAndQuestId(userId, questId)).willReturn(
                 Optional.of(expected));
@@ -175,6 +161,8 @@ public class ParticipantsTest {
         final Long badgeId = 2L;
         final Long userId = 3L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+
         final Participant expected = new Participant(userId, quest);
         given(participantRepository.findByUserIdAndQuestId(userId, questId)).willReturn(
                 Optional.of(expected));

--- a/src/test/java/daybyquest/participant/domain/ParticipantsTest.java
+++ b/src/test/java/daybyquest/participant/domain/ParticipantsTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.group.domain.GroupUsers;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
 import daybyquest.user.domain.Users;
@@ -31,6 +32,9 @@ public class ParticipantsTest {
     @Mock
     private Quests quests;
 
+    @Mock
+    private GroupUsers groupUsers;
+
     @InjectMocks
     private Participants participants;
 
@@ -41,6 +45,7 @@ public class ParticipantsTest {
         final Long badgeId = 2L;
         final Long userId = 3L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
         given(quests.getById(questId)).willReturn(quest);
 
         // when
@@ -62,12 +67,46 @@ public class ParticipantsTest {
         final Long badgeId = 2L;
         final Long userId = 3L;
         final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
         given(quests.getById(questId)).willReturn(quest);
         given(participantRepository.existsByUserIdAndQuestId(userId, questId)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> participants.saveWithUserIdAndQuestId(userId, questId))
                 .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 참여_시_수행_불가능한_퀘스트_라면_예외를_던진다() {
+        // given
+        final Long questId = 1L;
+        final Long badgeId = 2L;
+        final Long userId = 3L;
+        final Quest quest = QUEST_1.일반_퀘스트_생성(questId, badgeId);
+        QUEST_1.세부사항을_설정한다(quest);
+        given(quests.getById(questId)).willReturn(quest);
+        given(participantRepository.existsByUserIdAndQuestId(userId, questId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> participants.saveWithUserIdAndQuestId(userId, questId))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 참여_시_그룹_퀘스트_라면_그룹에_속했는지를_검사한다() {
+        // given
+        final Long questId = 1L;
+        final Long groupId = 2L;
+        final Long userId = 3L;
+        final Quest quest = QUEST_1.그룹_퀘스트_생성(questId, groupId);
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
+        given(quests.getById(questId)).willReturn(quest);
+
+        // when
+        participants.saveWithUserIdAndQuestId(userId, questId);
+
+        // then
+        then(groupUsers).should().validateExistentByUserIdAndGroupId(userId, groupId);
     }
 
     @Test

--- a/src/test/java/daybyquest/participant/query/ParticipantDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/participant/query/ParticipantDaoQuerydslImplTest.java
@@ -32,6 +32,10 @@ public class ParticipantDaoQuerydslImplTest extends QuerydslTest {
         final Quest 끝난_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 계속하는_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 진행중인_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        QUEST_1.보상_없이_세부사항을_설정한다(진행중인_퀘스트_1);
+        QUEST_2.보상_없이_세부사항을_설정한다(끝난_퀘스트);
+        QUEST_2.보상_없이_세부사항을_설정한다(계속하는_퀘스트);
+        QUEST_2.보상_없이_세부사항을_설정한다(진행중인_퀘스트_2);
 
         저장한다(new Participant(userId, 진행중인_퀘스트_1));
         퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트)));
@@ -57,6 +61,10 @@ public class ParticipantDaoQuerydslImplTest extends QuerydslTest {
         final Quest 계속하는_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 끝난_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 진행중인_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
+        QUEST_1.보상_없이_세부사항을_설정한다(계속하는_퀘스트_1);
+        QUEST_2.보상_없이_세부사항을_설정한다(끝난_퀘스트);
+        QUEST_2.보상_없이_세부사항을_설정한다(계속하는_퀘스트_2);
+        QUEST_2.보상_없이_세부사항을_설정한다(진행중인_퀘스트);
 
         퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트_1)));
         퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트_2)));
@@ -82,7 +90,11 @@ public class ParticipantDaoQuerydslImplTest extends QuerydslTest {
         final Quest 끝난_퀘스트_2 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 계속하는_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
         final Quest 진행_중인_퀘스트 = 저장한다(QUEST_2.일반_퀘스트_생성());
-        
+        QUEST_1.보상_없이_세부사항을_설정한다(끝난_퀘스트_1);
+        QUEST_2.보상_없이_세부사항을_설정한다(끝난_퀘스트_2);
+        QUEST_2.보상_없이_세부사항을_설정한다(계속하는_퀘스트);
+        QUEST_2.보상_없이_세부사항을_설정한다(진행_중인_퀘스트);
+
         퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트_1)));
         퀘스트를_끝낸다(저장한다(new Participant(userId, 끝난_퀘스트_2)));
         퀘스트를_계속한다(저장한다(new Participant(userId, 계속하는_퀘스트)));

--- a/src/test/java/daybyquest/quest/domain/QuestTest.java
+++ b/src/test/java/daybyquest/quest/domain/QuestTest.java
@@ -1,11 +1,18 @@
 package daybyquest.quest.domain;
 
-import static daybyquest.quest.domain.QuestState.ACTIVE;
+import static daybyquest.global.error.ExceptionCode.ALREADY_LABELED;
+import static daybyquest.global.error.ExceptionCode.CANNOT_PARTICIPATE;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_CONTENT;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_EXPIRED_AT;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_IMAGES;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_IMAGE_DESCRIPTION;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_NAME;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_REWARD;
+import static daybyquest.global.error.ExceptionCode.INVALID_QUEST_REWARD_COUNT;
+import static daybyquest.global.error.ExceptionCode.NOT_EXIST_GROUP;
 import static daybyquest.support.fixture.QuestFixtures.QUEST_1;
 import static daybyquest.support.util.StringUtils.문자열을_만든다;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import daybyquest.global.error.exception.InvalidDomainException;
 import daybyquest.image.domain.Image;
@@ -22,47 +29,15 @@ public class QuestTest {
     class 일반_퀘스트_생성은 {
 
         @Test
-        void 제목이_비어있으면_예외를_던진다() {
-            // given
-            final String title = "";
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 제목이_30자를_넘으면_예외를_던진다() {
-            // given
-            final String title = 문자열을_만든다(31);
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 내용이_300자를_넘으면_예외를_던진다() {
-            // given
-            final String content = 문자열을_만든다(501);
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
         void 사진_설명이_비어있으면_예외를_던진다() {
             // given
             final String imageDescription = "";
 
             // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createNormalQuest(null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGE_DESCRIPTION.getMessage());
         }
 
         @Test
@@ -71,27 +46,10 @@ public class QuestTest {
             final String imageDescription = 문자열을_만든다(101);
 
             // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @ParameterizedTest
-        @ValueSource(longs = {0L, -1L, -1111L})
-        void 목표치가_1보다_작으면_예외를_던진다(final Long rewardCount) {
-            // given & when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @ParameterizedTest
-        @ValueSource(longs = {366L, 1000L})
-        void 목표치가_365보다_크면_예외를_던진다(final Long rewardCount) {
-            // given & when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, rewardCount, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createNormalQuest(null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGE_DESCRIPTION.getMessage());
         }
 
         @Test
@@ -101,9 +59,10 @@ public class QuestTest {
                     new Image("사진3"), new Image("사진4"));
 
             // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createNormalQuest(null, QUEST_1.imageDescription, images, QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGES.getMessage());
         }
 
         @Test
@@ -112,25 +71,10 @@ public class QuestTest {
             final List<Image> images = List.of(new Image("사진1"), new Image("사진2"));
 
             // when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 보상이_없는데_목표치가_있으면_예외를_던진다() {
-            // given & when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, 1L, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 보상이_있는데_목표치가_없으면_예외를_던진다() {
-            // given & when & then
-            assertThatThrownBy(() -> Quest.createNormalQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createNormalQuest(null, QUEST_1.imageDescription, images, QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGES.getMessage());
         }
     }
 
@@ -140,42 +84,10 @@ public class QuestTest {
         @Test
         void 그룹_ID가_없으면_예외를_던진다() {
             // given & when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(null, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 제목이_비어있으면_예외를_던진다() {
-            // given
-            final String title = "";
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 제목이_30자를_넘으면_예외를_던진다() {
-            // given
-            final String title = 문자열을_만든다(31);
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
-        }
-
-        @Test
-        void 내용이_300자를_넘으면_예외를_던진다() {
-            // given
-            final String content = 문자열을_만든다(501);
-
-            // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    content, null, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createGroupQuest(null, QUEST_1.interest, QUEST_1.사진_목록(), QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(NOT_EXIST_GROUP.getMessage());
         }
 
         @Test
@@ -184,9 +96,10 @@ public class QuestTest {
             final String imageDescription = "";
 
             // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createGroupQuest(1L, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGE_DESCRIPTION.getMessage());
         }
 
         @Test
@@ -195,9 +108,10 @@ public class QuestTest {
             final String imageDescription = 문자열을_만든다(101);
 
             // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createGroupQuest(1L, imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGE_DESCRIPTION.getMessage());
         }
 
         @Test
@@ -207,9 +121,10 @@ public class QuestTest {
                     new Image("사진3"), new Image("사진4"));
 
             // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createGroupQuest(1L, QUEST_1.imageDescription, images, QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGES.getMessage());
         }
 
         @Test
@@ -218,50 +133,138 @@ public class QuestTest {
             final List<Image> images = List.of(new Image("사진1"), new Image("사진2"));
 
             // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, null, QUEST_1.imageDescription, images, QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(() ->
+                    Quest.createGroupQuest(1L, QUEST_1.imageDescription, images, QUEST_1.사진()))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_IMAGES.getMessage());
+        }
+    }
+
+    @Nested
+    class 세부_사항_설정은 {
+
+        @Test
+        void 이미_활성화된_퀘스트라면_예외를_던진다() {
+            // given
+            final Quest quest = QUEST_1.일반_퀘스트_생성();
+            QUEST_1.보상_없이_세부사항을_설정한다(quest);
+
+            // when & then
+            assertThatThrownBy(() -> QUEST_1.보상_없이_세부사항을_설정한다(quest))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(ALREADY_LABELED.getMessage());
+        }
+
+        @Test
+        void 제목이_비어있으면_예외를_던진다() {
+            // given
+            final String title = "";
+            final Quest quest = QUEST_1.그룹_퀘스트_생성(1L);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(title, QUEST_1.content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, null))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_NAME.getMessage());
+        }
+
+        @Test
+        void 제목이_30자를_넘으면_예외를_던진다() {
+            // given
+            final String title = 문자열을_만든다(31);
+            final Quest quest = QUEST_1.그룹_퀘스트_생성(1L);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(title, QUEST_1.content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, null))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_NAME.getMessage());
+        }
+
+        @Test
+        void 내용이_300자를_넘으면_예외를_던진다() {
+            // given
+            final String content = 문자열을_만든다(501);
+            final Quest quest = QUEST_1.그룹_퀘스트_생성(1L);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(QUEST_1.title, content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, null))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_CONTENT.getMessage());
         }
 
         @Test
         void 만료_시간이_현재보다_전이면_예외를_던진다() {
             // given
             final LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+            final Quest quest = QUEST_1.그룹_퀘스트_생성(1L);
 
             // when & then
-            assertThatThrownBy(() -> Quest.createGroupQuest(1L, QUEST_1.interest, QUEST_1.title,
-                    QUEST_1.content, expiredAt, QUEST_1.imageDescription, QUEST_1.사진_목록(), QUEST_1.사진()))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(
+                    () -> quest.setDetail(QUEST_1.title, QUEST_1.content, QUEST_1.interest, expiredAt,
+                            QUEST_1.label, null))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_EXPIRED_AT.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {0L, -1L, -1111L, 366L, 1000L})
+        void 목표치가_1에서_365가_아니면_예외를_던진다(final Long rewardCount) {
+            // given
+            final Quest quest = QUEST_1.일반_퀘스트_생성(1L);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(QUEST_1.title, QUEST_1.content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, rewardCount))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_REWARD_COUNT.getMessage());
+        }
+
+        @Test
+        void 보상이_없는데_목표치가_있으면_예외를_던진다() {
+            // given
+            final Quest quest = QUEST_1.일반_퀘스트_생성();
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(QUEST_1.title, QUEST_1.content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, QUEST_1.rewardCount))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_REWARD.getMessage());
+        }
+
+        @Test
+        void 보상이_있는데_목표치가_없으면_예외를_던진다() {
+            // given
+            final Quest quest = QUEST_1.일반_퀘스트_생성(1L);
+
+            // when & then
+            assertThatThrownBy(
+                    () -> quest.setDetail(QUEST_1.title, QUEST_1.content, QUEST_1.interest, QUEST_1.expiredAt,
+                            QUEST_1.label, null))
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(INVALID_QUEST_REWARD.getMessage());
         }
     }
 
     @Nested
-    class 라벨_설정은 {
+    class 참가_가능_여부_검증은 {
 
         @Test
-        void 새로_만든_퀘스트였다면_퀘스트를_활성화하고_라벨을_설정한다() {
+        void 라벨_필요_상태라면_예외를_던진다() {
             // given
-            final Quest quest = QUEST_1.일반_퀘스트_생성();
-
-            // when
-            quest.setLabel(QUEST_1.label);
-
-            // then
-            assertAll(() -> {
-                assertThat(quest.getState()).isEqualTo(ACTIVE);
-                assertThat(quest.getLabel()).isEqualTo(QUEST_1.label);
-            });
-        }
-
-        @Test
-        void 이미_활성화된_퀘스트라면_예외를_던진다() {
-            // given
-            final Quest quest = QUEST_1.일반_퀘스트_생성();
-            quest.setLabel(QUEST_1.label);
+            final Quest quest = QUEST_1.일반_퀘스트_생성(1L);
 
             // when & then
-            assertThatThrownBy(() -> quest.setLabel(QUEST_1.label))
-                    .isInstanceOf(InvalidDomainException.class);
+            assertThatThrownBy(quest::validateCanParticipate)
+                    .isInstanceOf(InvalidDomainException.class)
+                    .hasMessageContaining(CANNOT_PARTICIPATE.getMessage());
         }
+
     }
 }

--- a/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
@@ -47,6 +47,7 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         // given
         final Long userId = 1L;
         final Quest quest = 저장한다(QUEST_1.일반_퀘스트_생성());
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
 
         // when
         final QuestData questData = questDao.getById(userId, quest.getId());
@@ -66,6 +67,7 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         final Long userId = 1L;
         final Badge badge = 저장한다(BADGE_1.생성());
         final Quest quest = 저장한다(QUEST_1.일반_퀘스트_생성(badge));
+        QUEST_1.세부사항을_설정한다(quest);
 
         // when
         final QuestData questData = questDao.getById(userId, quest.getId());
@@ -84,6 +86,7 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         final Long userId = 1L;
         final Long groupId = 2L;
         final Quest quest = 저장한다(QUEST_1.그룹_퀘스트_생성(groupId));
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
 
         // when
         final QuestData questData = questDao.getById(userId, quest.getId());

--- a/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
@@ -143,6 +143,7 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         final User charlie = 저장한다(CHARLIE.생성());
         final User david = 저장한다(DAVID.생성());
         final Quest quest = 저장한다(QUEST_1.일반_퀘스트_생성());
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
 
         저장한다(new Participant(alice.getId(), quest));
         저장한다(퀘스트를_끝낸다(new Participant(bob.getId(), quest)));

--- a/src/test/java/daybyquest/support/fixture/QuestFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/QuestFixtures.java
@@ -51,12 +51,7 @@ public enum QuestFixtures {
     }
 
     public Quest 일반_퀘스트_생성(final Long id, final Long badgeId) {
-        Long rewardCount = this.rewardCount;
-        if (badgeId == null) {
-            rewardCount = null;
-        }
-        final Quest quest = Quest.createNormalQuest(badgeId, interest, title, content, rewardCount,
-                imageDescription, 사진_목록(), 사진());
+        final Quest quest = Quest.createNormalQuest(badgeId, imageDescription, 사진_목록(), 사진());
         ReflectionTestUtils.setField(quest, "id", id);
         return quest;
     }
@@ -70,13 +65,11 @@ public enum QuestFixtures {
     }
 
     public Quest 일반_퀘스트_생성(final Badge badge) {
-        return Quest.createNormalQuest(badge.getId(), interest, title, content, rewardCount,
-                imageDescription, 사진_목록(), badge.getImage());
+        return Quest.createNormalQuest(badge.getId(), imageDescription, 사진_목록(), badge.getImage());
     }
 
     public Quest 그룹_퀘스트_생성(final Long id, final Long groupId) {
-        final Quest quest = Quest.createGroupQuest(groupId, interest, title, content, expiredAt,
-                imageDescription, 사진_목록(), 사진());
+        final Quest quest = Quest.createGroupQuest(groupId, imageDescription, 사진_목록(), 사진());
         ReflectionTestUtils.setField(quest, "id", id);
         return quest;
     }
@@ -86,8 +79,15 @@ public enum QuestFixtures {
     }
 
     public Quest 그룹_퀘스트_생성(final Group group) {
-        return Quest.createGroupQuest(group.getId(), interest, title, content, expiredAt,
-                imageDescription, 사진_목록(), group.getImage());
+        return Quest.createGroupQuest(group.getId(), imageDescription, 사진_목록(), group.getImage());
+    }
+
+    public void 세부사항을_설정한다(final Quest quest) {
+        quest.setDetail(title, content, interest, expiredAt, label, rewardCount);
+    }
+
+    public void 보상_없이_세부사항을_설정한다(final Quest quest) {
+        quest.setDetail(title, content, interest, expiredAt, label, null);
     }
 
     public List<Image> 사진_목록() {


### PR DESCRIPTION
## 🗒️ Summary
### 리팩토링
- 이제 퀘스트 생성 시엔 최소한의 정보만 받은 후, AI 서버에 요청을 보냄
- 사용자는 AI 서버에서 받은 응답을 기준으로 나머지 내용을 작성하여 `상세 내용 저장` API를 호출해야함
- 퀘스트 수행 시엔, 위 과정이 모두 완료된 `ACTIVE` 상태의 퀘스트만 수행가능함-> 검증을 거침
- 그 외 유효성 검증 추가
### 기능 구현
- 일반 퀘스트, 그룹 퀘스트 생성 과정을 분리하여 구현
- 세부 사항 설정 API또한 분리하여 구현함
 
> #67

## 💡 More
- 