### PR TITLE
[Feature] 그룹 게시물 판정, 목록 조회, 그룹 퀘스트 조회를 구현한다

### DIFF
--- a/src/main/java/daybyquest/post/application/CheckPostService.java
+++ b/src/main/java/daybyquest/post/application/CheckPostService.java
@@ -1,0 +1,48 @@
+package daybyquest.post.application;
+
+import daybyquest.group.domain.GroupUsers;
+import daybyquest.post.domain.Post;
+import daybyquest.post.domain.Posts;
+import daybyquest.post.domain.SuccessfullyPostLinkedEvent;
+import daybyquest.post.dto.request.CheckPostRequest;
+import daybyquest.quest.domain.Quest;
+import daybyquest.quest.domain.Quests;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CheckPostService {
+
+
+    private final Quests quests;
+
+    private final GroupUsers groupUsers;
+
+    private final Posts posts;
+
+    private final ApplicationEventPublisher publisher;
+
+    public CheckPostService(final Quests quests, final GroupUsers groupUsers, final Posts posts,
+            final ApplicationEventPublisher publisher) {
+        this.quests = quests;
+        this.groupUsers = groupUsers;
+        this.posts = posts;
+        this.publisher = publisher;
+    }
+
+    @Transactional
+    public void invoke(final Long loginId, final Long postId, final CheckPostRequest request) {
+        final Post post = posts.getById(postId);
+        final Long questId = post.getQuestId();
+        final Quest quest = quests.getById(questId);
+        groupUsers.validateGroupManager(loginId, quest.getGroupId());
+        final boolean approval = request.isApproval();
+        if (approval) {
+            post.success();
+            publisher.publishEvent(new SuccessfullyPostLinkedEvent(post.getUserId(), post.getQuestId()));
+            return;
+        }
+        post.fail();
+    }
+}

--- a/src/main/java/daybyquest/post/application/GetNeedCheckPostsService.java
+++ b/src/main/java/daybyquest/post/application/GetNeedCheckPostsService.java
@@ -1,0 +1,39 @@
+package daybyquest.post.application;
+
+import daybyquest.group.domain.GroupUsers;
+import daybyquest.image.domain.Image;
+import daybyquest.post.domain.Post;
+import daybyquest.post.domain.Posts;
+import daybyquest.post.dto.response.NeedCheckPostsResponse;
+import daybyquest.post.dto.response.SimplePostResponse;
+import daybyquest.quest.domain.Quest;
+import daybyquest.quest.domain.Quests;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetNeedCheckPostsService {
+
+    private final Quests quests;
+
+    private final GroupUsers groupUsers;
+
+    private final Posts posts;
+
+    public GetNeedCheckPostsService(final Quests quests, final GroupUsers groupUsers, final Posts posts) {
+        this.quests = quests;
+        this.groupUsers = groupUsers;
+        this.posts = posts;
+    }
+
+    @Transactional(readOnly = true)
+    public NeedCheckPostsResponse invoke(final Long loginId, final Long questId) {
+        final Quest quest = quests.getById(questId);
+        groupUsers.validateGroupManager(loginId, quest.getGroupId());
+        final List<Post> posts = this.posts.findTop10NeedCheckPostByQuestId(questId);
+        final List<SimplePostResponse> responses = posts.stream().map(SimplePostResponse::of).toList();
+        return new NeedCheckPostsResponse(
+                quest.getImages().stream().map(Image::getIdentifier).toList(), responses);
+    }
+}

--- a/src/main/java/daybyquest/post/application/GetPostByGroupIdService.java
+++ b/src/main/java/daybyquest/post/application/GetPostByGroupIdService.java
@@ -1,0 +1,30 @@
+package daybyquest.post.application;
+
+import daybyquest.global.query.LongIdList;
+import daybyquest.global.query.NoOffsetIdPage;
+import daybyquest.post.dto.response.PagePostsResponse;
+import daybyquest.post.query.PostDao;
+import daybyquest.post.query.PostData;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetPostByGroupIdService {
+
+    private final PostDao postDao;
+
+    private final PostResponseConverter converter;
+
+    public GetPostByGroupIdService(final PostDao postDao, final PostResponseConverter converter) {
+        this.postDao = postDao;
+        this.converter = converter;
+    }
+
+    @Transactional(readOnly = true)
+    public PagePostsResponse invoke(final Long loginId, final Long groupId, final NoOffsetIdPage page) {
+        final LongIdList postIds = postDao.findPostIdsByGroupId(loginId, groupId, page);
+        final List<PostData> postData = postDao.findAllByIdIn(loginId, postIds.getIds());
+        return new PagePostsResponse(converter.convertFromPostData(loginId, postData), postIds.getLastId());
+    }
+}

--- a/src/main/java/daybyquest/post/domain/Post.java
+++ b/src/main/java/daybyquest/post/domain/Post.java
@@ -5,6 +5,7 @@ import static daybyquest.global.error.ExceptionCode.INVALID_POST_CONTENT;
 import static daybyquest.global.error.ExceptionCode.INVALID_POST_IMAGE;
 import static daybyquest.global.error.ExceptionCode.NOT_EXIST_USER;
 import static daybyquest.global.error.ExceptionCode.NOT_LINKED_POST;
+import static daybyquest.post.domain.PostState.FAIL;
 import static daybyquest.post.domain.PostState.NEED_CHECK;
 import static daybyquest.post.domain.PostState.NOT_DECIDED;
 import static daybyquest.post.domain.PostState.SUCCESS;
@@ -104,7 +105,7 @@ public class Post {
 
     public void success() {
         validateQuestLink();
-        if (state != NOT_DECIDED) {
+        if (state != NOT_DECIDED && state != NEED_CHECK) {
             throw new InvalidDomainException(ALREADY_JUDGED_POST);
         }
         state = SUCCESS;
@@ -116,6 +117,14 @@ public class Post {
             throw new InvalidDomainException(ALREADY_JUDGED_POST);
         }
         state = NEED_CHECK;
+    }
+
+    public void fail() {
+        validateQuestLink();
+        if (state != NEED_CHECK) {
+            throw new InvalidDomainException(ALREADY_JUDGED_POST);
+        }
+        state = FAIL;
     }
 
     public boolean isQuestLinked() {

--- a/src/main/java/daybyquest/post/domain/PostRepository.java
+++ b/src/main/java/daybyquest/post/domain/PostRepository.java
@@ -1,5 +1,6 @@
 package daybyquest.post.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
@@ -11,4 +12,5 @@ interface PostRepository extends Repository<Post, Long> {
 
     Optional<Post> findById(final Long id);
 
+    List<Post> findTop10ByQuestIdAndState(final Long questId, final PostState state);
 }

--- a/src/main/java/daybyquest/post/domain/Posts.java
+++ b/src/main/java/daybyquest/post/domain/Posts.java
@@ -1,8 +1,11 @@
 package daybyquest.post.domain;
 
+import static daybyquest.post.domain.PostState.NEED_CHECK;
+
 import daybyquest.global.error.exception.NotExistPostException;
 import daybyquest.participant.domain.Participants;
 import daybyquest.user.domain.Users;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,5 +39,9 @@ public class Posts {
         if (!postRepository.existsById(postId)) {
             throw new NotExistPostException();
         }
+    }
+
+    public List<Post> findTop10NeedCheckPostByQuestId(final Long questId) {
+        return postRepository.findTop10ByQuestIdAndState(questId, NEED_CHECK);
     }
 }

--- a/src/main/java/daybyquest/post/dto/request/CheckPostRequest.java
+++ b/src/main/java/daybyquest/post/dto/request/CheckPostRequest.java
@@ -1,0 +1,12 @@
+package daybyquest.post.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckPostRequest {
+
+    private boolean approval;
+
+}

--- a/src/main/java/daybyquest/post/dto/response/NeedCheckPostsResponse.java
+++ b/src/main/java/daybyquest/post/dto/response/NeedCheckPostsResponse.java
@@ -1,0 +1,7 @@
+package daybyquest.post.dto.response;
+
+import java.util.List;
+
+public record NeedCheckPostsResponse(List<String> images, List<SimplePostResponse> posts) {
+
+}

--- a/src/main/java/daybyquest/post/dto/response/SimplePostResponse.java
+++ b/src/main/java/daybyquest/post/dto/response/SimplePostResponse.java
@@ -1,0 +1,15 @@
+package daybyquest.post.dto.response;
+
+import daybyquest.image.domain.Image;
+import daybyquest.post.domain.Post;
+import java.util.List;
+
+public record SimplePostResponse(Long id, List<String> imageIdentifiers) {
+
+    public static SimplePostResponse of(final Post post) {
+        return new SimplePostResponse(
+                post.getId(), post.getImages().stream().map(Image::getIdentifier).toList()
+        );
+    }
+
+}

--- a/src/main/java/daybyquest/post/presentation/PostCommandApi.java
+++ b/src/main/java/daybyquest/post/presentation/PostCommandApi.java
@@ -2,10 +2,12 @@ package daybyquest.post.presentation;
 
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
+import daybyquest.post.application.CheckPostService;
 import daybyquest.post.application.GetPostService;
 import daybyquest.post.application.JudgePostService;
 import daybyquest.post.application.SavePostService;
 import daybyquest.post.application.SwipePostService;
+import daybyquest.post.dto.request.CheckPostRequest;
 import daybyquest.post.dto.request.JudgePostRequest;
 import daybyquest.post.dto.request.SavePostRequest;
 import daybyquest.post.dto.response.PostWithQuestResponse;
@@ -30,12 +32,16 @@ public class PostCommandApi {
 
     private final JudgePostService judgePostService;
 
+    private final CheckPostService checkPostService;
+
     public PostCommandApi(final SavePostService savePostService, final SwipePostService swipePostService,
-            final GetPostService getPostService, final JudgePostService judgePostService) {
+            final GetPostService getPostService, final JudgePostService judgePostService,
+            final CheckPostService checkPostService) {
         this.savePostService = savePostService;
         this.swipePostService = swipePostService;
         this.getPostService = getPostService;
         this.judgePostService = judgePostService;
+        this.checkPostService = checkPostService;
     }
 
     @PostMapping("/post")
@@ -60,6 +66,14 @@ public class PostCommandApi {
     public ResponseEntity<Void> swipePost(final AccessUser accessUser,
             @PathVariable final Long postId, @RequestBody final JudgePostRequest request) {
         judgePostService.invoke(postId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/group/{postId}/post")
+    @Authorization
+    public ResponseEntity<Void> checkGroupPost(final AccessUser accessUser,
+            @PathVariable final Long postId, @RequestBody final CheckPostRequest request) {
+        checkPostService.invoke(accessUser.getId(), postId, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/daybyquest/post/presentation/PostQueryApi.java
+++ b/src/main/java/daybyquest/post/presentation/PostQueryApi.java
@@ -3,11 +3,13 @@ package daybyquest.post.presentation;
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
 import daybyquest.global.query.NoOffsetIdPage;
+import daybyquest.post.application.GetNeedCheckPostsService;
 import daybyquest.post.application.GetPostByQuestIdService;
 import daybyquest.post.application.GetPostByUsernameService;
 import daybyquest.post.application.GetPostFromFollowingService;
 import daybyquest.post.application.GetPostService;
 import daybyquest.post.application.GetTrackerService;
+import daybyquest.post.dto.response.NeedCheckPostsResponse;
 import daybyquest.post.dto.response.PagePostsResponse;
 import daybyquest.post.dto.response.PostWithQuestResponse;
 import daybyquest.post.dto.response.TrackerResponse;
@@ -29,16 +31,20 @@ public class PostQueryApi {
 
     private final GetPostByQuestIdService getPostByQuestIdService;
 
+    private final GetNeedCheckPostsService getNeedCheckPostsService;
+
     public PostQueryApi(final GetPostService getPostService,
             final GetPostFromFollowingService getPostFromFollowingService,
             final GetPostByUsernameService getPostByUsernameService,
             final GetTrackerService getTrackerService,
-            final GetPostByQuestIdService getPostByQuestIdService) {
+            final GetPostByQuestIdService getPostByQuestIdService,
+            final GetNeedCheckPostsService getNeedCheckPostsService) {
         this.getPostService = getPostService;
         this.getPostFromFollowingService = getPostFromFollowingService;
         this.getPostByUsernameService = getPostByUsernameService;
         this.getTrackerService = getTrackerService;
         this.getPostByQuestIdService = getPostByQuestIdService;
+        this.getNeedCheckPostsService = getNeedCheckPostsService;
     }
 
     @GetMapping("/post/{postId}")
@@ -80,6 +86,14 @@ public class PostQueryApi {
             @PathVariable final Long questId, final NoOffsetIdPage page) {
         final PagePostsResponse response = getPostByQuestIdService.invoke(accessUser.getId(), questId,
                 page);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/group/{questId}/quest/failed")
+    @Authorization
+    public ResponseEntity<NeedCheckPostsResponse> getNeedCheckPosts(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        final NeedCheckPostsResponse response = getNeedCheckPostsService.invoke(accessUser.getId(), questId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/daybyquest/post/presentation/PostQueryApi.java
+++ b/src/main/java/daybyquest/post/presentation/PostQueryApi.java
@@ -4,6 +4,7 @@ import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
 import daybyquest.global.query.NoOffsetIdPage;
 import daybyquest.post.application.GetNeedCheckPostsService;
+import daybyquest.post.application.GetPostByGroupIdService;
 import daybyquest.post.application.GetPostByQuestIdService;
 import daybyquest.post.application.GetPostByUsernameService;
 import daybyquest.post.application.GetPostFromFollowingService;
@@ -31,6 +32,8 @@ public class PostQueryApi {
 
     private final GetPostByQuestIdService getPostByQuestIdService;
 
+    private final GetPostByGroupIdService getPostByGroupIdService;
+
     private final GetNeedCheckPostsService getNeedCheckPostsService;
 
     public PostQueryApi(final GetPostService getPostService,
@@ -38,12 +41,14 @@ public class PostQueryApi {
             final GetPostByUsernameService getPostByUsernameService,
             final GetTrackerService getTrackerService,
             final GetPostByQuestIdService getPostByQuestIdService,
+            final GetPostByGroupIdService getPostByGroupIdService,
             final GetNeedCheckPostsService getNeedCheckPostsService) {
         this.getPostService = getPostService;
         this.getPostFromFollowingService = getPostFromFollowingService;
         this.getPostByUsernameService = getPostByUsernameService;
         this.getTrackerService = getTrackerService;
         this.getPostByQuestIdService = getPostByQuestIdService;
+        this.getPostByGroupIdService = getPostByGroupIdService;
         this.getNeedCheckPostsService = getNeedCheckPostsService;
     }
 
@@ -85,6 +90,15 @@ public class PostQueryApi {
     public ResponseEntity<PagePostsResponse> getPostByQuestId(final AccessUser accessUser,
             @PathVariable final Long questId, final NoOffsetIdPage page) {
         final PagePostsResponse response = getPostByQuestIdService.invoke(accessUser.getId(), questId,
+                page);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/group/{groupId}/post")
+    @Authorization
+    public ResponseEntity<PagePostsResponse> getPostByGroupId(final AccessUser accessUser,
+            @PathVariable final Long groupId, final NoOffsetIdPage page) {
+        final PagePostsResponse response = getPostByGroupIdService.invoke(accessUser.getId(), groupId,
                 page);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/daybyquest/post/query/PostDao.java
+++ b/src/main/java/daybyquest/post/query/PostDao.java
@@ -16,6 +16,8 @@ public interface PostDao {
 
     LongIdList findPostIdsByQuestId(final Long userId, final Long questId, final NoOffsetIdPage page);
 
+    LongIdList findPostIdsByGroupId(final Long userId, final Long groupId, final NoOffsetIdPage page);
+
     List<PostData> findAllByIdIn(final Long userId, final Collection<Long> postIds);
 
     List<SimplePostData> findAllBySuccessAndUploadedAtAfter(final Long userId, final LocalDateTime time);

--- a/src/main/java/daybyquest/post/query/PostDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/post/query/PostDaoQuerydslImpl.java
@@ -110,6 +110,17 @@ public class PostDaoQuerydslImpl implements PostDao {
     }
 
     @Override
+    public LongIdList findPostIdsByGroupId(final Long userId, final Long groupId, final NoOffsetIdPage page) {
+        return new LongIdList(factory.select(post.id)
+                .from(post)
+                .join(quest).on(quest.groupId.eq(groupId), quest.id.eq(post.questId))
+                .where(ltPostId(page.lastId()))
+                .orderBy(post.id.desc())
+                .limit(page.limit())
+                .fetch());
+    }
+
+    @Override
     public List<PostData> findAllByIdIn(final Long userId, final Collection<Long> postIds) {
         final Map<Long, PostData> postDataMap = factory.from(post)
                 .where(post.id.in(postIds))

--- a/src/main/java/daybyquest/quest/application/group/GetGroupQuestsService.java
+++ b/src/main/java/daybyquest/quest/application/group/GetGroupQuestsService.java
@@ -1,0 +1,26 @@
+package daybyquest.quest.application.group;
+
+import daybyquest.quest.dto.response.MultipleQuestsResponse;
+import daybyquest.quest.dto.response.QuestResponse;
+import daybyquest.quest.query.QuestDao;
+import daybyquest.quest.query.QuestData;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetGroupQuestsService {
+
+    private final QuestDao questDao;
+
+    public GetGroupQuestsService(final QuestDao questDao) {
+        this.questDao = questDao;
+    }
+
+    @Transactional(readOnly = true)
+    public MultipleQuestsResponse invoke(final Long loginId, final Long groupId) {
+        final List<QuestData> questData = questDao.findAllByGroupId(loginId, groupId);
+        final List<QuestResponse> responses = questData.stream().map(QuestResponse::of).toList();
+        return new MultipleQuestsResponse(responses);
+    }
+}

--- a/src/main/java/daybyquest/quest/application/group/GroupQuestValidator.java
+++ b/src/main/java/daybyquest/quest/application/group/GroupQuestValidator.java
@@ -1,4 +1,4 @@
-package daybyquest.quest.application;
+package daybyquest.quest.application.group;
 
 import daybyquest.group.domain.GroupUsers;
 import daybyquest.quest.domain.Quest;

--- a/src/main/java/daybyquest/quest/application/group/SaveGroupQuestDetailService.java
+++ b/src/main/java/daybyquest/quest/application/group/SaveGroupQuestDetailService.java
@@ -1,4 +1,4 @@
-package daybyquest.quest.application;
+package daybyquest.quest.application.group;
 
 import daybyquest.group.domain.GroupUsers;
 import daybyquest.quest.domain.Quest;

--- a/src/main/java/daybyquest/quest/application/group/SaveGroupQuestService.java
+++ b/src/main/java/daybyquest/quest/application/group/SaveGroupQuestService.java
@@ -1,4 +1,4 @@
-package daybyquest.quest.application;
+package daybyquest.quest.application.group;
 
 import daybyquest.global.utils.MultipartFileUtils;
 import daybyquest.group.domain.Group;
@@ -7,6 +7,7 @@ import daybyquest.group.domain.Groups;
 import daybyquest.image.domain.Image;
 import daybyquest.image.domain.ImageIdentifierGenerator;
 import daybyquest.image.domain.Images;
+import daybyquest.quest.application.QuestClient;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
 import daybyquest.quest.dto.request.SaveGroupQuestRequest;

--- a/src/main/java/daybyquest/quest/application/group/SubscribeGroupQuestLabelsService.java
+++ b/src/main/java/daybyquest/quest/application/group/SubscribeGroupQuestLabelsService.java
@@ -1,5 +1,6 @@
-package daybyquest.quest.application;
+package daybyquest.quest.application.group;
 
+import daybyquest.quest.application.QuestSseEmitters;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/src/main/java/daybyquest/quest/presentation/GroupQuestCommandApi.java
+++ b/src/main/java/daybyquest/quest/presentation/GroupQuestCommandApi.java
@@ -1,0 +1,66 @@
+package daybyquest.quest.presentation;
+
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+
+import daybyquest.auth.Authorization;
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.quest.application.SaveGroupQuestDetailService;
+import daybyquest.quest.application.SaveGroupQuestService;
+import daybyquest.quest.application.SubscribeGroupQuestLabelsService;
+import daybyquest.quest.dto.request.SaveGroupQuestDetailRequest;
+import daybyquest.quest.dto.request.SaveGroupQuestRequest;
+import daybyquest.quest.dto.response.SaveQuestResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class GroupQuestCommandApi {
+
+    private final SaveGroupQuestService saveGroupQuestService;
+
+    private final SaveGroupQuestDetailService saveGroupQuestDetailService;
+
+    private final SubscribeGroupQuestLabelsService subscribeGroupQuestLabelsService;
+
+    public GroupQuestCommandApi(final SaveGroupQuestService saveGroupQuestService,
+            final SaveGroupQuestDetailService saveGroupQuestDetailService,
+            final SubscribeGroupQuestLabelsService subscribeGroupQuestLabelsService) {
+        this.saveGroupQuestService = saveGroupQuestService;
+        this.saveGroupQuestDetailService = saveGroupQuestDetailService;
+        this.subscribeGroupQuestLabelsService = subscribeGroupQuestLabelsService;
+    }
+
+    @PostMapping("/group/quest")
+    @Authorization
+    public ResponseEntity<SaveQuestResponse> saveGroupQuest(final AccessUser accessUser,
+            @RequestPart SaveGroupQuestRequest request,
+            @RequestPart List<MultipartFile> files) {
+        final Long questId = saveGroupQuestService.invoke(accessUser.getId(), request, files);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
+    }
+
+    @PostMapping("/group/{questId}/quest/detail")
+    @Authorization
+    public ResponseEntity<SaveQuestResponse> saveGroupQuestDetail(final AccessUser accessUser,
+            @PathVariable final Long questId, @RequestBody @Valid SaveGroupQuestDetailRequest request) {
+        saveGroupQuestDetailService.invoke(accessUser.getId(), questId, request);
+        return ResponseEntity.ok(new SaveQuestResponse(questId));
+    }
+
+    @GetMapping(value = "/group/{questId}/quest/labels", produces = TEXT_EVENT_STREAM_VALUE)
+    @Authorization
+    public ResponseEntity<SseEmitter> subscribeGroupQuestLabels(final AccessUser accessUser,
+            @PathVariable final Long questId) {
+        final SseEmitter emitter = subscribeGroupQuestLabelsService.invoke(accessUser.getId(), questId);
+        return ResponseEntity.ok(emitter);
+    }
+}

--- a/src/main/java/daybyquest/quest/presentation/GroupQuestCommandApi.java
+++ b/src/main/java/daybyquest/quest/presentation/GroupQuestCommandApi.java
@@ -4,9 +4,9 @@ import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
-import daybyquest.quest.application.SaveGroupQuestDetailService;
-import daybyquest.quest.application.SaveGroupQuestService;
-import daybyquest.quest.application.SubscribeGroupQuestLabelsService;
+import daybyquest.quest.application.group.SaveGroupQuestDetailService;
+import daybyquest.quest.application.group.SaveGroupQuestService;
+import daybyquest.quest.application.group.SubscribeGroupQuestLabelsService;
 import daybyquest.quest.dto.request.SaveGroupQuestDetailRequest;
 import daybyquest.quest.dto.request.SaveGroupQuestRequest;
 import daybyquest.quest.dto.response.SaveQuestResponse;

--- a/src/main/java/daybyquest/quest/presentation/GroupQuestQueryApi.java
+++ b/src/main/java/daybyquest/quest/presentation/GroupQuestQueryApi.java
@@ -1,0 +1,26 @@
+package daybyquest.quest.presentation;
+
+import daybyquest.auth.domain.AccessUser;
+import daybyquest.quest.application.group.GetGroupQuestsService;
+import daybyquest.quest.dto.response.MultipleQuestsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GroupQuestQueryApi {
+
+    private final GetGroupQuestsService getGroupQuestsService;
+
+    public GroupQuestQueryApi(final GetGroupQuestsService getGroupQuestsService) {
+        this.getGroupQuestsService = getGroupQuestsService;
+    }
+
+    @GetMapping("/group/{groupId}/quest")
+    public ResponseEntity<MultipleQuestsResponse> getGroupQuests(final AccessUser accessUser,
+            @PathVariable final Long groupId) {
+        final MultipleQuestsResponse response = getGroupQuestsService.invoke(accessUser.getId(), groupId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
+++ b/src/main/java/daybyquest/quest/presentation/QuestCommandApi.java
@@ -4,16 +4,11 @@ import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
 import daybyquest.auth.Authorization;
 import daybyquest.auth.domain.AccessUser;
-import daybyquest.quest.application.SaveGroupQuestDetailService;
-import daybyquest.quest.application.SaveGroupQuestService;
 import daybyquest.quest.application.SaveQuestDetailService;
 import daybyquest.quest.application.SaveQuestService;
 import daybyquest.quest.application.SendQuestLabelsService;
-import daybyquest.quest.application.SubscribeGroupQuestLabelsService;
 import daybyquest.quest.application.SubscribeQuestLabelsService;
 import daybyquest.quest.dto.request.QuestLabelsRequest;
-import daybyquest.quest.dto.request.SaveGroupQuestDetailRequest;
-import daybyquest.quest.dto.request.SaveGroupQuestRequest;
 import daybyquest.quest.dto.request.SaveQuestDetailRequest;
 import daybyquest.quest.dto.request.SaveQuestRequest;
 import daybyquest.quest.dto.response.SaveQuestResponse;
@@ -35,31 +30,19 @@ public class QuestCommandApi {
 
     private final SaveQuestService saveQuestService;
 
-    private final SaveGroupQuestService saveGroupQuestService;
-
     private final SaveQuestDetailService saveQuestDetailService;
 
-    private final SaveGroupQuestDetailService saveGroupQuestDetailService;
-
     private final SubscribeQuestLabelsService subscribeQuestLabelsService;
-
-    private final SubscribeGroupQuestLabelsService subscribeGroupQuestLabelsService;
 
     private final SendQuestLabelsService sendQuestLabelsService;
 
     public QuestCommandApi(final SaveQuestService saveQuestService,
-            final SaveGroupQuestService saveGroupQuestService,
             final SaveQuestDetailService saveQuestDetailService,
-            final SaveGroupQuestDetailService saveGroupQuestDetailService,
             final SubscribeQuestLabelsService subscribeQuestLabelsService,
-            final SubscribeGroupQuestLabelsService subscribeGroupQuestLabelsService,
             final SendQuestLabelsService sendQuestLabelsService) {
         this.saveQuestService = saveQuestService;
-        this.saveGroupQuestService = saveGroupQuestService;
         this.saveQuestDetailService = saveQuestDetailService;
-        this.saveGroupQuestDetailService = saveGroupQuestDetailService;
         this.subscribeQuestLabelsService = subscribeQuestLabelsService;
-        this.subscribeGroupQuestLabelsService = subscribeGroupQuestLabelsService;
         this.sendQuestLabelsService = sendQuestLabelsService;
     }
 
@@ -72,15 +55,6 @@ public class QuestCommandApi {
         return ResponseEntity.ok(new SaveQuestResponse(questId));
     }
 
-    @PostMapping("/group/quest")
-    @Authorization
-    public ResponseEntity<SaveQuestResponse> saveGroupQuest(final AccessUser accessUser,
-            @RequestPart SaveGroupQuestRequest request,
-            @RequestPart List<MultipartFile> files) {
-        final Long questId = saveGroupQuestService.invoke(accessUser.getId(), request, files);
-        return ResponseEntity.ok(new SaveQuestResponse(questId));
-    }
-
     @PostMapping("/quest/{questId}/detail")
     @Authorization(admin = true)
     public ResponseEntity<SaveQuestResponse> saveQuestDetail(final AccessUser accessUser,
@@ -89,27 +63,11 @@ public class QuestCommandApi {
         return ResponseEntity.ok(new SaveQuestResponse(questId));
     }
 
-    @PostMapping("/group/{questId}/quest/detail")
-    @Authorization
-    public ResponseEntity<SaveQuestResponse> saveGroupQuestDetail(final AccessUser accessUser,
-            @PathVariable final Long questId, @RequestBody @Valid SaveGroupQuestDetailRequest request) {
-        saveGroupQuestDetailService.invoke(accessUser.getId(), questId, request);
-        return ResponseEntity.ok(new SaveQuestResponse(questId));
-    }
-
     @GetMapping(value = "/quest/{questId}/labels", produces = TEXT_EVENT_STREAM_VALUE)
     @Authorization(admin = true)
     public ResponseEntity<SseEmitter> subscribeQuestLabels(final AccessUser accessUser,
             @PathVariable final Long questId) {
         final SseEmitter emitter = subscribeQuestLabelsService.invoke(questId);
-        return ResponseEntity.ok(emitter);
-    }
-
-    @GetMapping(value = "/group/{questId}/quest/labels", produces = TEXT_EVENT_STREAM_VALUE)
-    @Authorization
-    public ResponseEntity<SseEmitter> subscribeGroupQuestLabels(final AccessUser accessUser,
-            @PathVariable final Long questId) {
-        final SseEmitter emitter = subscribeGroupQuestLabelsService.invoke(accessUser.getId(), questId);
         return ResponseEntity.ok(emitter);
     }
 

--- a/src/main/java/daybyquest/quest/query/QuestDao.java
+++ b/src/main/java/daybyquest/quest/query/QuestDao.java
@@ -7,5 +7,7 @@ public interface QuestDao {
 
     QuestData getById(final Long userId, final Long id);
 
+    List<QuestData> findAllByGroupId(final Long userId, final Long groupId);
+
     List<QuestData> findAllByIdIn(final Long userId, final Collection<Long> ids);
 }

--- a/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
@@ -61,6 +61,14 @@ public class QuestDaoQuerydslImpl implements QuestDao {
     }
 
     @Override
+    public List<QuestData> findAllByGroupId(final Long userId, final Long groupId) {
+        return factory.select(projectQuestData(userId, quest.id))
+                .from(quest)
+                .join(group).on(group.id.eq(groupId), group.id.eq(quest.groupId))
+                .fetch();
+    }
+
+    @Override
     public List<QuestData> findAllByIdIn(final Long userId, final Collection<Long> ids) {
         return factory.select(projectQuestData(userId, quest.id))
                 .from(quest)

--- a/src/test/java/daybyquest/post/domain/PostTest.java
+++ b/src/test/java/daybyquest/post/domain/PostTest.java
@@ -68,10 +68,23 @@ public class PostTest {
     }
 
     @Test
-    void 퀘스트_링크_성공_처리_시_이미_판정된_퀘스트라면_예외를_던진다() {
+    void 확인_필요_상태_에서_퀘스트_링크를_성공_처리한다() {
         // given
         final Post post = POST_1.생성(1L, 2L);
         post.needCheck();
+
+        // when
+        post.success();
+
+        // then
+        assertThat(post.getState()).isEqualTo(PostState.SUCCESS);
+    }
+
+    @Test
+    void 퀘스트_링크_성공_처리_시_이미_판정된_퀘스트라면_예외를_던진다() {
+        // given
+        final Post post = POST_1.생성(1L, 2L);
+        post.success();
 
         // when & then
         assertThatThrownBy(post::success)
@@ -118,6 +131,39 @@ public class PostTest {
 
         // when & then
         assertThatThrownBy(post::needCheck)
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 퀘스트_링크를_실패_처리_한다() {
+        // given
+        final Post post = POST_1.생성(1L, 2L);
+        post.needCheck();
+
+        // when
+        post.fail();
+
+        // then
+        assertThat(post.getState()).isEqualTo(PostState.FAIL);
+    }
+
+    @Test
+    void 퀘스트_링크_실패_처리_시_확인_필요_상태가_아니라면_예외를_던진다() {
+        // given
+        final Post post = POST_1.생성(1L, 2L);
+
+        // when & then
+        assertThatThrownBy(post::fail)
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    @Test
+    void 퀘스트_링크_실패_처리_시_퀘스트와_연관이_없다면_예외를_던진다() {
+        // given
+        final Post post = POST_1.생성(1L);
+
+        // when & then
+        assertThatThrownBy(post::fail)
                 .isInstanceOf(InvalidDomainException.class);
     }
 

--- a/src/test/java/daybyquest/post/query/PostDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/post/query/PostDaoQuerydslImplTest.java
@@ -1,11 +1,13 @@
 package daybyquest.post.query;
 
+import static daybyquest.support.fixture.GroupFixtures.GROUP_1;
 import static daybyquest.support.fixture.PostFixtures.POST_1;
 import static daybyquest.support.fixture.PostFixtures.POST_2;
 import static daybyquest.support.fixture.PostFixtures.POST_3;
 import static daybyquest.support.fixture.PostFixtures.POST_4;
 import static daybyquest.support.fixture.PostFixtures.POST_WITH_3_IMAGES;
 import static daybyquest.support.fixture.QuestFixtures.QUEST_1;
+import static daybyquest.support.fixture.QuestFixtures.QUEST_2;
 import static daybyquest.support.fixture.UserFixtures.ALICE;
 import static daybyquest.support.fixture.UserFixtures.BOB;
 import static daybyquest.support.fixture.UserFixtures.CHARLIE;
@@ -15,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import daybyquest.global.query.LongIdList;
 import daybyquest.global.query.NoOffsetIdPage;
+import daybyquest.group.domain.Group;
 import daybyquest.post.domain.Post;
 import daybyquest.quest.domain.Quest;
 import daybyquest.relation.domain.Follow;
@@ -163,6 +166,27 @@ public class PostDaoQuerydslImplTest extends QuerydslTest {
 
         // when
         final LongIdList ids = postDao.findPostIdsByQuestId(bob.getId(), quest.getId(), page);
+
+        // then
+        assertThat(ids.getIds()).hasSize(3);
+    }
+
+    @Test
+    void 그룹_ID를_통해_게시물_ID_목록을_조회한다() {
+        // given
+        final User bob = 저장한다(BOB.생성());
+        final Group group = 저장한다(GROUP_1.생성());
+        final Quest quest1 = 저장한다(QUEST_1.그룹_퀘스트_생성(group));
+        final Quest quest2 = 저장한다(QUEST_2.그룹_퀘스트_생성(group));
+        저장한다(POST_1.생성(bob, quest1));
+        저장한다(POST_2.생성(bob, quest2));
+        저장한다(POST_3.생성(bob, quest2));
+        저장한다(POST_4.생성(bob));
+
+        final NoOffsetIdPage page = new NoOffsetIdPage(null, 5);
+
+        // when
+        final LongIdList ids = postDao.findPostIdsByGroupId(bob.getId(), group.getId(), page);
 
         // then
         assertThat(ids.getIds()).hasSize(3);

--- a/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
@@ -8,6 +8,7 @@ import static daybyquest.quest.domain.QuestCategory.GROUP;
 import static daybyquest.quest.domain.QuestCategory.NORMAL;
 import static daybyquest.support.fixture.BadgeFixtures.BADGE_1;
 import static daybyquest.support.fixture.GroupFixtures.GROUP_1;
+import static daybyquest.support.fixture.GroupFixtures.GROUP_2;
 import static daybyquest.support.fixture.PostFixtures.POST_1;
 import static daybyquest.support.fixture.PostFixtures.POST_2;
 import static daybyquest.support.fixture.PostFixtures.POST_3;
@@ -169,6 +170,29 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         // given & when & then
         assertThatThrownBy(() -> questDao.getById(1L, 2L))
                 .isInstanceOf(NotExistQuestException.class);
+    }
+
+    @Test
+    void 그룹_ID로_퀘스트를_조회한다() {
+        // given
+        final Long userId = 1L;
+        final Group group1 = 저장한다(GROUP_1.생성());
+        final Group group2 = 저장한다(GROUP_2.생성());
+        final Quest quest1 = 저장한다(QUEST_1.그룹_퀘스트_생성(group1));
+        final Quest quest2 = 저장한다(QUEST_2.그룹_퀘스트_생성(group1));
+        final Quest quest3 = 저장한다(QUEST_1.그룹_퀘스트_생성(group1));
+        저장한다(QUEST_3.그룹_퀘스트_생성(group2));
+        final List<Long> expected = List.of(quest1.getId(), quest2.getId(), quest3.getId());
+
+        // when
+        final List<QuestData> questData = questDao.findAllByGroupId(userId, group1.getId());
+        final List<Long> actual = questData.stream().map(QuestData::getId).toList();
+
+        // then
+        assertAll(() -> {
+            assertThat(questData).hasSize(3);
+            assertThat(actual).containsExactlyElementsOf(expected);
+        });
     }
 
     @Test


### PR DESCRIPTION
## 🗒️ Summary
### 리팩토링
- 퀘스트 API와 그룹 퀘스트 관련 API를 분리한다
  - 퀘스트 도메인은 복잡하고 많은 API를 가지고 있어 구분하기 어려움 -> 분리
- 응용 클래스의 패키지도 분리
- `Post` 도메인에 실패처리 관련 로직을 추가
### 구현
- 확인이 필요한 그룹 퀘스트 목록 조회
- 그룹장의 그룹 퀘스트 판정
- 그룹 퀘스트 목록
- 그룹 게시물 목록

> #67 

## 💡 More
- 