### PR TITLE
[Refactor] 사진 업로드 관련 로직에서 S3에 고아 객체가 생성될 확률을 줄인다

### DIFF
--- a/src/main/java/daybyquest/badge/application/SaveBadgeService.java
+++ b/src/main/java/daybyquest/badge/application/SaveBadgeService.java
@@ -2,10 +2,8 @@ package daybyquest.badge.application;
 
 import daybyquest.badge.domain.Badge;
 import daybyquest.badge.domain.Badges;
-import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,21 +15,16 @@ public class SaveBadgeService {
 
     private final Badges badges;
 
-    private final Images images;
+    private final ImageService imageService;
 
-    private final ImageIdentifierGenerator generator;
-
-    public SaveBadgeService(final Badges badges, final Images images,
-            final ImageIdentifierGenerator generator) {
+    public SaveBadgeService(final Badges badges, final ImageService imageService) {
         this.badges = badges;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
     }
 
     @Transactional
     public void invoke(final String name, final MultipartFile file) {
-        final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-        final Image image = images.upload(identifier, MultipartFileUtils.getInputStream(file));
+        final Image image = imageService.convertToImage(CATEGORY, file);
         final Badge badge = new Badge(name, image);
         badges.save(badge);
     }

--- a/src/main/java/daybyquest/group/application/SaveGroupService.java
+++ b/src/main/java/daybyquest/group/application/SaveGroupService.java
@@ -1,12 +1,10 @@
 package daybyquest.group.application;
 
-import daybyquest.global.utils.MultipartFileUtils;
 import daybyquest.group.domain.Group;
 import daybyquest.group.domain.Groups;
 import daybyquest.group.dto.request.SaveGroupRequest;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,21 +16,16 @@ public class SaveGroupService {
 
     private final Groups groups;
 
-    private final Images images;
+    private final ImageService imageService;
 
-    private final ImageIdentifierGenerator generator;
-
-    public SaveGroupService(final Groups groups, final Images images,
-            final ImageIdentifierGenerator generator) {
+    public SaveGroupService(final Groups groups, final ImageService imageService) {
         this.groups = groups;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
     }
 
     @Transactional
     public Long invoke(final Long loginId, final SaveGroupRequest request, final MultipartFile file) {
-        final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-        final Image image = images.upload(identifier, MultipartFileUtils.getInputStream(file));
+        final Image image = imageService.convertToImage(CATEGORY, file);
         final Group group = toEntity(request, image);
         return groups.save(loginId, group);
     }

--- a/src/main/java/daybyquest/image/application/ImageService.java
+++ b/src/main/java/daybyquest/image/application/ImageService.java
@@ -1,0 +1,33 @@
+package daybyquest.image.application;
+
+import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.domain.Image;
+import daybyquest.image.domain.ImageIdentifierGenerator;
+import daybyquest.image.domain.ImageRemovedEvent;
+import daybyquest.image.domain.ImageSavedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class ImageService {
+
+    private final ImageIdentifierGenerator generator;
+
+    private final ApplicationEventPublisher publisher;
+
+    public ImageService(final ImageIdentifierGenerator generator, final ApplicationEventPublisher publisher) {
+        this.generator = generator;
+        this.publisher = publisher;
+    }
+
+    public Image convertToImage(final String category, final MultipartFile file) {
+        final String identifier = generator.generate(category, file.getOriginalFilename());
+        publisher.publishEvent(new ImageSavedEvent(identifier, MultipartFileUtils.getInputStream(file)));
+        return new Image(identifier);
+    }
+
+    public void remove(final String identifier) {
+        publisher.publishEvent(new ImageRemovedEvent(identifier));
+    }
+}

--- a/src/main/java/daybyquest/image/domain/ImageRemovedEvent.java
+++ b/src/main/java/daybyquest/image/domain/ImageRemovedEvent.java
@@ -1,0 +1,7 @@
+package daybyquest.image.domain;
+
+import daybyquest.global.event.Event;
+
+public record ImageRemovedEvent(String identifier) implements Event {
+
+}

--- a/src/main/java/daybyquest/image/domain/ImageSavedEvent.java
+++ b/src/main/java/daybyquest/image/domain/ImageSavedEvent.java
@@ -1,0 +1,8 @@
+package daybyquest.image.domain;
+
+import daybyquest.global.event.Event;
+import java.io.InputStream;
+
+public record ImageSavedEvent(String identifier, InputStream inputStream) implements Event {
+
+}

--- a/src/main/java/daybyquest/image/domain/Images.java
+++ b/src/main/java/daybyquest/image/domain/Images.java
@@ -4,7 +4,7 @@ import java.io.InputStream;
 
 public interface Images {
 
-    Image upload(final String identifier, final InputStream imageStream);
+    void upload(final String identifier, final InputStream imageStream);
 
     void remove(final String identifier);
 }

--- a/src/main/java/daybyquest/image/infra/S3Images.java
+++ b/src/main/java/daybyquest/image/infra/S3Images.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import daybyquest.global.error.exception.InvalidFileException;
-import daybyquest.image.domain.Image;
 import daybyquest.image.domain.Images;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +24,7 @@ public class S3Images implements Images {
     }
 
     @Override
-    public Image upload(final String identifier, final InputStream imageStream) {
+    public void upload(final String identifier, final InputStream imageStream) {
         try {
             final ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(imageStream.available());
@@ -33,7 +32,6 @@ public class S3Images implements Images {
                     bucket, identifier, imageStream, metadata
             );
             amazonS3.putObject(putObjectRequest);
-            return new Image(identifier);
         } catch (IOException e) {
             throw new InvalidFileException();
         }

--- a/src/main/java/daybyquest/image/listener/RemoveImageListener.java
+++ b/src/main/java/daybyquest/image/listener/RemoveImageListener.java
@@ -1,0 +1,26 @@
+package daybyquest.image.listener;
+
+import static org.springframework.transaction.event.TransactionPhase.BEFORE_COMMIT;
+
+import daybyquest.image.domain.ImageRemovedEvent;
+import daybyquest.image.domain.Images;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+public class RemoveImageListener {
+
+    private final Images images;
+
+    public RemoveImageListener(final Images images) {
+        this.images = images;
+    }
+
+    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    public void listenImageRemovedEvent(final ImageRemovedEvent event) {
+        log.debug("S3 delete. identifier: {}", event.identifier());
+        images.remove(event.identifier());
+    }
+}

--- a/src/main/java/daybyquest/image/listener/UploadImageListener.java
+++ b/src/main/java/daybyquest/image/listener/UploadImageListener.java
@@ -1,0 +1,26 @@
+package daybyquest.image.listener;
+
+import static org.springframework.transaction.event.TransactionPhase.BEFORE_COMMIT;
+
+import daybyquest.image.domain.ImageSavedEvent;
+import daybyquest.image.domain.Images;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@Slf4j
+public class UploadImageListener {
+
+    private final Images images;
+
+    public UploadImageListener(final Images images) {
+        this.images = images;
+    }
+
+    @TransactionalEventListener(phase = BEFORE_COMMIT)
+    public void listenImageSavedEvent(final ImageSavedEvent event) {
+        log.debug("S3 Upload. identifier: {}", event.identifier());
+        images.upload(event.identifier(), event.inputStream());
+    }
+}

--- a/src/main/java/daybyquest/interest/application/SaveInterestService.java
+++ b/src/main/java/daybyquest/interest/application/SaveInterestService.java
@@ -1,9 +1,7 @@
 package daybyquest.interest.application;
 
-import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import daybyquest.interest.domain.Interest;
 import daybyquest.interest.domain.Interests;
 import daybyquest.interest.dto.request.SaveInterestRequest;
@@ -18,21 +16,16 @@ public class SaveInterestService {
 
     private final Interests interests;
 
-    private final Images images;
+    private final ImageService imageService;
 
-    private final ImageIdentifierGenerator generator;
-
-    public SaveInterestService(final Interests interests, final Images images,
-            final ImageIdentifierGenerator generator) {
+    public SaveInterestService(final Interests interests, final ImageService imageService) {
         this.interests = interests;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
     }
 
     @Transactional
     public void invoke(final SaveInterestRequest request, final MultipartFile file) {
-        final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-        final Image image = images.upload(identifier, MultipartFileUtils.getInputStream(file));
+        final Image image = imageService.convertToImage(CATEGORY, file);
         final Interest interest = new Interest(request.getName(), image);
         interests.save(interest);
     }

--- a/src/main/java/daybyquest/post/application/SavePostService.java
+++ b/src/main/java/daybyquest/post/application/SavePostService.java
@@ -1,9 +1,7 @@
 package daybyquest.post.application;
 
-import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import daybyquest.post.domain.Post;
 import daybyquest.post.domain.Posts;
 import daybyquest.post.dto.request.SavePostRequest;
@@ -20,19 +18,16 @@ public class SavePostService {
 
     private final Posts posts;
 
-    private final Images images;
-
-    private final ImageIdentifierGenerator generator;
+    private final ImageService imageService;
 
     private final PostClient postClient;
 
     private final Quests quests;
 
-    public SavePostService(final Posts posts, final Images images,
-            final ImageIdentifierGenerator generator, final PostClient postClient, final Quests quests) {
+    public SavePostService(final Posts posts, final ImageService imageService, final PostClient postClient,
+            final Quests quests) {
         this.posts = posts;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
         this.postClient = postClient;
         this.quests = quests;
     }
@@ -46,10 +41,7 @@ public class SavePostService {
     }
 
     private List<Image> toImageList(final List<MultipartFile> files) {
-        return files.stream().map((file) -> {
-            final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-            return images.upload(identifier, MultipartFileUtils.getInputStream(file));
-        }).toList();
+        return files.stream().map((file) -> imageService.convertToImage(CATEGORY, file)).toList();
     }
 
     private Post toEntity(final Long loginId, final SavePostRequest request, final List<Image> images) {

--- a/src/main/java/daybyquest/quest/application/SaveQuestService.java
+++ b/src/main/java/daybyquest/quest/application/SaveQuestService.java
@@ -2,10 +2,8 @@ package daybyquest.quest.application;
 
 import daybyquest.badge.domain.Badge;
 import daybyquest.badge.domain.Badges;
-import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
 import daybyquest.quest.dto.request.SaveQuestRequest;
@@ -23,18 +21,15 @@ public class SaveQuestService {
 
     private final Badges badges;
 
-    private final Images images;
-
-    private final ImageIdentifierGenerator generator;
+    private final ImageService imageService;
 
     private final QuestClient questClient;
 
-    public SaveQuestService(final Quests quests, final Badges badges, final Images images,
-            final ImageIdentifierGenerator generator, final QuestClient questClient) {
+    public SaveQuestService(final Quests quests, final Badges badges, final ImageService imageService,
+            final QuestClient questClient) {
         this.quests = quests;
         this.badges = badges;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
         this.questClient = questClient;
     }
 
@@ -47,10 +42,7 @@ public class SaveQuestService {
     }
 
     private List<Image> toImageList(final List<MultipartFile> files) {
-        return files.stream().map((file) -> {
-            final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-            return images.upload(identifier, MultipartFileUtils.getInputStream(file));
-        }).toList();
+        return files.stream().map((file) -> imageService.convertToImage(CATEGORY, file)).toList();
     }
 
     private Quest toEntity(final SaveQuestRequest request, final List<Image> images) {

--- a/src/main/java/daybyquest/quest/application/group/SaveGroupQuestService.java
+++ b/src/main/java/daybyquest/quest/application/group/SaveGroupQuestService.java
@@ -1,12 +1,10 @@
 package daybyquest.quest.application.group;
 
-import daybyquest.global.utils.MultipartFileUtils;
 import daybyquest.group.domain.Group;
 import daybyquest.group.domain.GroupUsers;
 import daybyquest.group.domain.Groups;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import daybyquest.quest.application.QuestClient;
 import daybyquest.quest.domain.Quest;
 import daybyquest.quest.domain.Quests;
@@ -27,20 +25,16 @@ public class SaveGroupQuestService {
 
     private final GroupUsers groupUsers;
 
-    private final Images images;
-
-    private final ImageIdentifierGenerator generator;
+    private final ImageService imageService;
 
     private final QuestClient questClient;
 
     public SaveGroupQuestService(final Quests quests, final Groups groups, final GroupUsers groupUsers,
-            final Images images,
-            final ImageIdentifierGenerator generator, final QuestClient questClient) {
+            final ImageService imageService, final QuestClient questClient) {
         this.quests = quests;
         this.groups = groups;
         this.groupUsers = groupUsers;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
         this.questClient = questClient;
     }
 
@@ -55,10 +49,7 @@ public class SaveGroupQuestService {
     }
 
     private List<Image> toImageList(final List<MultipartFile> files) {
-        return files.stream().map((file) -> {
-            final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-            return images.upload(identifier, MultipartFileUtils.getInputStream(file));
-        }).toList();
+        return files.stream().map((file) -> imageService.convertToImage(CATEGORY, file)).toList();
     }
 
     private Quest toEntity(final SaveGroupQuestRequest request, final List<Image> images) {

--- a/src/main/java/daybyquest/user/application/DeleteUserImageService.java
+++ b/src/main/java/daybyquest/user/application/DeleteUserImageService.java
@@ -1,8 +1,8 @@
 package daybyquest.user.application;
 
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.BaseImageProperties;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.Images;
 import daybyquest.user.domain.User;
 import daybyquest.user.domain.Users;
 import org.springframework.stereotype.Service;
@@ -13,14 +13,14 @@ public class DeleteUserImageService {
 
     private final Users users;
 
-    private final Images images;
+    private final ImageService imageService;
 
     private final BaseImageProperties properties;
 
-    public DeleteUserImageService(final Users users, final Images images,
+    public DeleteUserImageService(final Users users, final ImageService imageService,
             final BaseImageProperties properties) {
         this.users = users;
-        this.images = images;
+        this.imageService = imageService;
         this.properties = properties;
     }
 
@@ -28,7 +28,7 @@ public class DeleteUserImageService {
     public void invoke(final Long loginId) {
         final User user = users.getById(loginId);
         if (properties.isNotBase(user.getImageIdentifier())) {
-            images.remove(user.getImageIdentifier());
+            imageService.remove(user.getImageIdentifier());
         }
         user.updateImage(new Image(properties.getUserIdentifier()));
     }

--- a/src/main/java/daybyquest/user/application/UpdateUserImageService.java
+++ b/src/main/java/daybyquest/user/application/UpdateUserImageService.java
@@ -1,10 +1,8 @@
 package daybyquest.user.application;
 
-import daybyquest.global.utils.MultipartFileUtils;
+import daybyquest.image.application.ImageService;
 import daybyquest.image.domain.BaseImageProperties;
 import daybyquest.image.domain.Image;
-import daybyquest.image.domain.ImageIdentifierGenerator;
-import daybyquest.image.domain.Images;
 import daybyquest.user.domain.User;
 import daybyquest.user.domain.Users;
 import org.springframework.stereotype.Service;
@@ -18,17 +16,14 @@ public class UpdateUserImageService {
 
     private final Users users;
 
-    private final Images images;
-
-    private final ImageIdentifierGenerator generator;
+    private final ImageService imageService;
 
     private final BaseImageProperties properties;
 
-    public UpdateUserImageService(final Users users, final Images images,
-            final ImageIdentifierGenerator generator, final BaseImageProperties properties) {
+    public UpdateUserImageService(final Users users, final ImageService imageService,
+            final BaseImageProperties properties) {
         this.users = users;
-        this.images = images;
-        this.generator = generator;
+        this.imageService = imageService;
         this.properties = properties;
     }
 
@@ -36,11 +31,10 @@ public class UpdateUserImageService {
     public void invoke(final Long loginId, final MultipartFile file) {
         final User user = users.getById(loginId);
         final String oldIdentifier = user.getImageIdentifier();
-        final String identifier = generator.generate(CATEGORY, file.getOriginalFilename());
-        final Image image = images.upload(identifier, MultipartFileUtils.getInputStream(file));
+        final Image image = imageService.convertToImage(CATEGORY, file);
         user.updateImage(image);
         if (properties.isNotBase(oldIdentifier)) {
-            images.remove(oldIdentifier);
+            imageService.remove(oldIdentifier);
         }
     }
 }


### PR DESCRIPTION
## 🗒️ Summary
- 이벤트처리를 통해, 업로드 로직을 트랜잭션의 맨 뒤로 보냄으로 S3 버킷에 고아 객체가 생성될 확률을 낮춤
- 

>resolve: #115

## 💡 More
- 