### PR TITLE
[Test] 그룹 API 테스트를 작성한다

### DIFF
--- a/src/docs/asciidoc/group.adoc
+++ b/src/docs/asciidoc/group.adoc
@@ -1,0 +1,49 @@
+= 관계 API
+:operation-http-request-title: HTTP 요청
+:operation-http-response-title: HTTP 응답
+
+== Command
+
+=== 그룹 생성
+
+operation::group/saveGroup[snippets='http-request,http-response,request-parts']
+
+=== 그룹 가입
+
+operation::group/saveMember[snippets='http-request,http-response']
+
+=== 그룹 탈퇴
+
+operation::group/deleteMember[snippets='http-request,http-response']
+
+== Query
+
+=== 그룹 이름 중복 검사
+
+operation::group/checkName[snippets='http-request,http-response']
+
+=== 그룹 프로필 조회
+
+operation::group/getGroup[snippets='http-request,http-response']
+
+=== 그룹원 목록 조회
+
+operation::group/getGroupUsers[snippets='http-request,http-response']
+
+=== 가입한 그룹 목록 조회
+
+operation::group/getGroups[snippets='http-request,http-response']
+
+=== 그룹 추천 받기
+
+operation::group/recommendGroups[snippets='http-request,http-response']
+
+=== 그룹 검색
+
+operation::group/searchGroups[snippets='http-request,http-response']
+
+=== 관심사로 그룹 목록 조회
+
+operation::group/getGroupsByInterest[snippets='http-request,http-response']
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,3 +5,4 @@
 * link:user[사용자 API]
 * link:relation[사용자 간 관계 API]
 * link:profile-setting[프로필 설정 API]
+* link:group[그룹 API]

--- a/src/main/java/daybyquest/global/error/ExceptionResponse.java
+++ b/src/main/java/daybyquest/global/error/ExceptionResponse.java
@@ -3,25 +3,15 @@ package daybyquest.global.error;
 import daybyquest.global.error.exception.CustomException;
 import java.util.Collections;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
-public class ExceptionResponse {
-
-    private final String code;
-
-    private final String message;
-
-    private final List<String> fields;
-
-    public ExceptionResponse(String code, String message, List<String> fields) {
-        this.code = code;
-        this.message = message;
-        this.fields = fields;
-    }
+public record ExceptionResponse(String code, String message, List<String> fields) {
 
     public static ExceptionResponse of(CustomException e) {
         return new ExceptionResponse(e.getCode(), e.getMessage(), e.getFields());
+    }
+
+    public static ExceptionResponse of(ExceptionCode errorCode, String field) {
+        return new ExceptionResponse(errorCode.getCode(), errorCode.getMessage(), List.of(field));
     }
 
     public static ExceptionResponse of(ExceptionCode errorCode, List<String> fields) {

--- a/src/main/java/daybyquest/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/daybyquest/global/error/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -24,11 +25,11 @@ import org.springframework.web.server.MissingRequestValueException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({
-        MissingServletRequestPartException.class,
-        MissingRequestValueException.class,
-        MethodArgumentTypeMismatchException.class,
-        HttpMessageNotReadableException.class,
-        HttpRequestMethodNotSupportedException.class
+            MissingServletRequestPartException.class,
+            MissingRequestValueException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class,
+            HttpRequestMethodNotSupportedException.class
     })
     public ResponseEntity<ExceptionResponse> handleHttpRequestException(Exception e) {
         log.warn(e.getMessage(), e);
@@ -37,11 +38,18 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    protected ResponseEntity<ExceptionResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        final ExceptionResponse response = ExceptionResponse.of(INVALID_INPUT, e.getParameterName());
+        return new ResponseEntity<>(response, INVALID_INPUT.getHttpStatus());
+    }
+
+    @ExceptionHandler
     protected ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException e) {
+            MethodArgumentNotValidException e) {
         log.debug(e.getMessage(), e);
         final ExceptionResponse response = ExceptionResponse.of(INVALID_INPUT,
-            convertBindingResult(e.getBindingResult())
+                convertBindingResult(e.getBindingResult())
         );
         return new ResponseEntity<>(response, INVALID_INPUT.getHttpStatus());
     }
@@ -62,7 +70,7 @@ public class GlobalExceptionHandler {
 
     private List<String> convertBindingResult(BindingResult bindingResult) {
         return bindingResult.getFieldErrors().stream()
-            .map(FieldError::getField)
-            .toList();
+                .map(FieldError::getField)
+                .toList();
     }
 }

--- a/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
+++ b/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
@@ -1,0 +1,113 @@
+package daybyquest.group.presentation;
+
+import static daybyquest.support.fixture.GroupFixtures.GROUP_1;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import daybyquest.group.application.DeleteMemberService;
+import daybyquest.group.application.SaveGroupService;
+import daybyquest.group.application.SaveMemberService;
+import daybyquest.group.domain.Group;
+import daybyquest.group.dto.request.SaveGroupRequest;
+import daybyquest.support.test.ApiTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest({GroupCommandApi.class})
+public class GroupCommandApiTest extends ApiTest {
+
+    @MockBean
+    private SaveGroupService saveGroupService;
+
+    @MockBean
+    private SaveMemberService saveMemberService;
+
+    @MockBean
+    private DeleteMemberService deleteMemberService;
+
+    @Test
+    void 그룹을_생성한다() throws Exception {
+        // given
+        given(saveGroupService.invoke(any(), any(), any())).willReturn(1L);
+        final SaveGroupRequest saveGroupRequest = 그룹_생성_요청(GROUP_1.생성());
+        final MockMultipartFile file =
+                new MockMultipartFile("image", "image.png",
+                        MediaType.MULTIPART_FORM_DATA_VALUE, "file content".getBytes());
+        final MockMultipartFile request =
+                new MockMultipartFile("request", "request",
+                        MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(saveGroupRequest));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                multipart("/group")
+                        .file(file)
+                        .file(request)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/saveGroup",
+                        requestParts(partWithName("image").description("사진 파일"),
+                                partWithName("request").description("요청")))
+                );
+        then(saveGroupService).should().invoke(eq(로그인_ID), any(), any());
+    }
+
+    @Test
+    void 그룹에_가입한다() throws Exception {
+        // given
+        final Long groupId = 2L;
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                post("/group/{groupId}/user", groupId)
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/saveMember"));
+        then(saveMemberService).should().invoke(로그인_ID, groupId);
+    }
+
+    @Test
+    void 그룹에_탈퇴한다() throws Exception {
+        // given
+        final Long groupId = 2L;
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                delete("/group/{groupId}/user", groupId)
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/deleteMember"));
+        then(deleteMemberService).should().invoke(로그인_ID, groupId);
+    }
+
+    private SaveGroupRequest 그룹_생성_요청(final Group group) {
+        final SaveGroupRequest request = new SaveGroupRequest();
+        ReflectionTestUtils.setField(request, "name", group.getName());
+        ReflectionTestUtils.setField(request, "description", group.getDescription());
+        ReflectionTestUtils.setField(request, "interest", group.getInterest());
+        return request;
+    }
+}

--- a/src/test/java/daybyquest/group/presentation/GroupQueryApiTest.java
+++ b/src/test/java/daybyquest/group/presentation/GroupQueryApiTest.java
@@ -1,0 +1,184 @@
+package daybyquest.group.presentation;
+
+import static daybyquest.support.fixture.GroupFixtures.GROUP_1;
+import static daybyquest.support.fixture.GroupFixtures.GROUP_2;
+import static daybyquest.support.fixture.UserFixtures.ALICE;
+import static daybyquest.support.fixture.UserFixtures.BOB;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import daybyquest.group.application.CheckGroupNameService;
+import daybyquest.group.application.GetGroupProfileService;
+import daybyquest.group.application.GetGroupUsersService;
+import daybyquest.group.application.GetGroupsByInterestService;
+import daybyquest.group.application.GetGroupsService;
+import daybyquest.group.application.RecommendGroupsService;
+import daybyquest.group.application.SearchGroupService;
+import daybyquest.group.dto.response.MultipleGroupsResponse;
+import daybyquest.group.dto.response.PageGroupUsersResponse;
+import daybyquest.group.dto.response.PageGroupsResponse;
+import daybyquest.support.test.ApiTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest({GroupQueryApi.class})
+public class GroupQueryApiTest extends ApiTest {
+
+    @MockBean
+    private CheckGroupNameService checkGroupNameService;
+
+    @MockBean
+    private GetGroupProfileService getGroupProfileService;
+
+    @MockBean
+    private GetGroupUsersService getGroupUsersService;
+
+    @MockBean
+    private GetGroupsService getGroupsService;
+
+    @MockBean
+    private RecommendGroupsService recommendGroupsService;
+
+    @MockBean
+    private SearchGroupService searchGroupService;
+
+    @MockBean
+    private GetGroupsByInterestService getGroupsByInterestService;
+
+    @Test
+    void 그룹_이름_중복_검사를_한다() throws Exception {
+        // given & when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/group/{groupName}/check", GROUP_1.name));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(문서화한다("group/checkName"));
+        then(checkGroupNameService).should().invoke(GROUP_1.name);
+    }
+
+    @Test
+    void 그룹_프로필을_조회한다() throws Exception {
+        // given
+        final Long groupId = 2L;
+        given(getGroupProfileService.invoke(로그인_ID, groupId)).willReturn(GROUP_1.응답(groupId));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/group/{groupId}", groupId)
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/getGroup"));
+        then(getGroupProfileService).should().invoke(로그인_ID, groupId);
+    }
+
+    @Test
+    void 그룹원_목록을_조회한다() throws Exception {
+        // given
+        final Long groupId = 2L;
+        given(getGroupUsersService.invoke(eq(로그인_ID), eq(groupId), any()))
+                .willReturn(new PageGroupUsersResponse(List.of(BOB.그룹원_응답(1L), ALICE.그룹원_응답(2L)), 2L));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/group/{groupId}/user", groupId)
+                        .param("limit", "5")
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/getGroupUsers"));
+        then(getGroupUsersService).should().invoke(eq(로그인_ID), eq(groupId), any());
+    }
+
+    @Test
+    void 가입한_그룹_목록을_조회한다() throws Exception {
+        // given
+        given(getGroupsService.invoke(로그인_ID))
+                .willReturn(new MultipleGroupsResponse(List.of(GROUP_1.응답(1L), GROUP_2.응답(2L))));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/group")
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/getGroups"));
+        then(getGroupsService).should().invoke(로그인_ID);
+    }
+
+    @Test
+    void 그룹을_추천받는다() throws Exception {
+        // given
+        given(recommendGroupsService.invoke(로그인_ID))
+                .willReturn(new MultipleGroupsResponse(List.of(GROUP_1.응답(1L), GROUP_2.응답(2L))));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/group/recommendation")
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/recommendGroups"));
+        then(recommendGroupsService).should().invoke(로그인_ID);
+    }
+
+    @Test
+    void 그룹을_검색한다() throws Exception {
+        // given
+        final String keyword = "키워드";
+        given(searchGroupService.invoke(eq(로그인_ID), eq(keyword), any()))
+                .willReturn(new PageGroupsResponse(List.of(GROUP_1.응답(1L), GROUP_2.응답(2L)), 2L));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/search/group")
+                        .param("keyword", keyword)
+                        .param("limit", "5")
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/searchGroups"));
+        then(searchGroupService).should().invoke(eq(로그인_ID), eq(keyword), any());
+    }
+
+    @Test
+    void 관심사로_그룹_목록을_조회한다() throws Exception {
+        // given
+        final String interest = "관심사1";
+        given(getGroupsByInterestService.invoke(eq(로그인_ID), eq(interest), any()))
+                .willReturn(new PageGroupsResponse(List.of(GROUP_1.응답(1L), GROUP_2.응답(2L)), 2L));
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(
+                get("/groups")
+                        .param("interest", interest)
+                        .param("limit", "5")
+                        .header("Authorization", "UserId 1"));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(인증_상태로_문서화한다("group/getGroupsByInterest"));
+        then(getGroupsByInterestService).should().invoke(eq(로그인_ID), eq(interest), any());
+    }
+}

--- a/src/test/java/daybyquest/support/fixture/GroupFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/GroupFixtures.java
@@ -1,6 +1,8 @@
 package daybyquest.support.fixture;
 
 import daybyquest.group.domain.Group;
+import daybyquest.group.dto.response.GroupResponse;
+import daybyquest.group.query.GroupData;
 import daybyquest.image.domain.Image;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -39,5 +41,11 @@ public enum GroupFixtures {
 
     public Image 대표_사진() {
         return new Image(this.imageIdentifier);
+    }
+
+    public GroupResponse 응답(final Long id) {
+        final GroupData groupData = new GroupData(id, name, description, interest, 대표_사진(),
+                0L, null);
+        return GroupResponse.of(groupData);
     }
 }

--- a/src/test/java/daybyquest/support/fixture/UserFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/UserFixtures.java
@@ -1,5 +1,9 @@
 package daybyquest.support.fixture;
 
+import static daybyquest.group.domain.GroupUserRole.MEMBER;
+
+import daybyquest.group.dto.response.GroupUserResponse;
+import daybyquest.group.query.GroupUserData;
 import daybyquest.image.domain.Image;
 import daybyquest.user.domain.User;
 import daybyquest.user.query.Profile;
@@ -43,5 +47,11 @@ public enum UserFixtures {
 
     public Profile 프로필(final Long id) {
         return new Profile(id, username, name, imageIdentifier, 0L, false, false);
+    }
+
+    public GroupUserResponse 그룹원_응답(final Long id) {
+        final GroupUserData groupUserData = new GroupUserData(id, username, name, imageIdentifier,
+                0L, false, false, MEMBER);
+        return GroupUserResponse.of(groupUserData);
     }
 }

--- a/src/test/java/daybyquest/support/test/ApiTest.java
+++ b/src/test/java/daybyquest/support/test/ApiTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.request.RequestPartsSnippet;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultHandler;
 
@@ -52,5 +53,13 @@ public abstract class ApiTest {
                         , prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestHeaders(headerWithName("Authorization").description("UserId 헤더")));
+    }
+
+    protected ResultHandler 인증_상태로_문서화한다(final String identifier, final RequestPartsSnippet snippet) {
+        return document(identifier, preprocessRequest(modifyHeaders().remove("Host").remove("Content-Length")
+                        , prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(headerWithName("Authorization").description("UserId 헤더")),
+                snippet);
     }
 }

--- a/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
+++ b/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
@@ -7,13 +7,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -154,9 +149,7 @@ public class UserCommandApiTest extends ApiTest {
         // then
         resultActions.andExpect(status().isOk())
                 .andDo(print())
-                .andDo(document("user/updateImage",
-                        preprocessResponse(prettyPrint()),
-                        requestHeaders(headerWithName("Authorization").description("UserId 헤더")),
+                .andDo(인증_상태로_문서화한다("user/updateImage",
                         requestParts(partWithName("image").description("사진 파일")))
                 );
         then(updateUserImageService).should().invoke(eq(로그인_ID), any(MultipartFile.class));


### PR DESCRIPTION
## 🗒️ Summary
### 추가 수정 사항
- `ExceptionResponse`를 레코드로 전환
- `@RequestParam`이 없을 경우에 대한 예외처리
- `Multipart` 관련 테스트 시, 공통된 문서화 작업을 메서드로 추출

> #128 

## 💡 More
- 