### PR TITLE
[Test] API 테스트의 가독성을 개선한다

### DIFF
--- a/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
+++ b/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
@@ -57,7 +57,7 @@ public class GroupCommandApiTest extends ApiTest {
                         .file(file)
                         .file(request)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -77,7 +77,7 @@ public class GroupCommandApiTest extends ApiTest {
         // when
         final ResultActions resultActions = mockMvc.perform(
                 post("/group/{groupId}/user", groupId)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -94,7 +94,7 @@ public class GroupCommandApiTest extends ApiTest {
         // when
         final ResultActions resultActions = mockMvc.perform(
                 delete("/group/{groupId}/user", groupId)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
+++ b/src/test/java/daybyquest/group/presentation/GroupCommandApiTest.java
@@ -44,12 +44,8 @@ public class GroupCommandApiTest extends ApiTest {
         // given
         given(saveGroupService.invoke(any(), any(), any())).willReturn(1L);
         final SaveGroupRequest saveGroupRequest = 그룹_생성_요청(GROUP_1.생성());
-        final MockMultipartFile file =
-                new MockMultipartFile("image", "image.png",
-                        MediaType.MULTIPART_FORM_DATA_VALUE, "file content".getBytes());
-        final MockMultipartFile request =
-                new MockMultipartFile("request", "request",
-                        MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(saveGroupRequest));
+        final MockMultipartFile file = 사진을_전송한다("image");
+        final MockMultipartFile request = 멀티파트_JSON을_전송한다("request", saveGroupRequest);
 
         // when
         final ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/daybyquest/group/presentation/GroupQueryApiTest.java
+++ b/src/test/java/daybyquest/group/presentation/GroupQueryApiTest.java
@@ -75,7 +75,7 @@ public class GroupQueryApiTest extends ApiTest {
         // when
         final ResultActions resultActions = mockMvc.perform(
                 get("/group/{groupId}", groupId)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -95,7 +95,7 @@ public class GroupQueryApiTest extends ApiTest {
         final ResultActions resultActions = mockMvc.perform(
                 get("/group/{groupId}/user", groupId)
                         .param("limit", "5")
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -113,7 +113,7 @@ public class GroupQueryApiTest extends ApiTest {
         // when
         final ResultActions resultActions = mockMvc.perform(
                 get("/group")
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -131,7 +131,7 @@ public class GroupQueryApiTest extends ApiTest {
         // when
         final ResultActions resultActions = mockMvc.perform(
                 get("/group/recommendation")
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -152,7 +152,7 @@ public class GroupQueryApiTest extends ApiTest {
                 get("/search/group")
                         .param("keyword", keyword)
                         .param("limit", "5")
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -173,7 +173,7 @@ public class GroupQueryApiTest extends ApiTest {
                 get("/groups")
                         .param("interest", interest)
                         .param("limit", "5")
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/profile/presentation/ProfileQueryApiTest.java
+++ b/src/test/java/daybyquest/profile/presentation/ProfileQueryApiTest.java
@@ -32,7 +32,7 @@ public class ProfileQueryApiTest extends ApiTest {
 
         // when
         final ResultActions resultActions = mockMvc.perform(get("/badge/{username}", ALICE.username)
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/profile/presentation/ProfileSettingCommandApiTest.java
+++ b/src/test/java/daybyquest/profile/presentation/ProfileSettingCommandApiTest.java
@@ -31,7 +31,7 @@ public class ProfileSettingCommandApiTest extends ApiTest {
 
         // when
         final ResultActions resultActions = mockMvc.perform(patch("/badge")
-                .header("Authorization", "UserId 1")
+                .header(인증_헤더_이름, 사용자_인증_헤더)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
 

--- a/src/test/java/daybyquest/relation/presentation/FollowCommandApiTest.java
+++ b/src/test/java/daybyquest/relation/presentation/FollowCommandApiTest.java
@@ -33,7 +33,7 @@ public class FollowCommandApiTest extends ApiTest {
         // given & when
         final ResultActions resultActions = mockMvc.perform(
                 post("/profile/{username}/follow", ALICE.username)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -47,7 +47,7 @@ public class FollowCommandApiTest extends ApiTest {
         // given & when
         final ResultActions resultActions = mockMvc.perform(
                 delete("/profile/{username}/follow", ALICE.username)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -61,7 +61,7 @@ public class FollowCommandApiTest extends ApiTest {
         // given & when
         final ResultActions resultActions = mockMvc.perform(
                 delete("/profile/{username}/follower", ALICE.username)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더ㄴ));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/relation/presentation/FollowCommandApiTest.java
+++ b/src/test/java/daybyquest/relation/presentation/FollowCommandApiTest.java
@@ -61,7 +61,7 @@ public class FollowCommandApiTest extends ApiTest {
         // given & when
         final ResultActions resultActions = mockMvc.perform(
                 delete("/profile/{username}/follower", ALICE.username)
-                        .header(인증_헤더_이름, 사용자_인증_헤더ㄴ));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/relation/presentation/FollowQueryApiTest.java
+++ b/src/test/java/daybyquest/relation/presentation/FollowQueryApiTest.java
@@ -42,7 +42,7 @@ public class FollowQueryApiTest extends ApiTest {
         final ResultActions resultActions = mockMvc.perform(get("/followings")
                 .param("limit", "5")
                 .param("lastId", "0")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -63,7 +63,7 @@ public class FollowQueryApiTest extends ApiTest {
         final ResultActions resultActions = mockMvc.perform(get("/followers")
                 .param("limit", "5")
                 .param("lastId", "0")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
+++ b/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
@@ -123,7 +123,7 @@ public class UserCommandApiTest extends ApiTest {
         final ResultActions resultActions = mockMvc.perform(patch("/profile/interest")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -144,7 +144,7 @@ public class UserCommandApiTest extends ApiTest {
                 multipart(HttpMethod.PATCH, "/profile/image")
                         .file(file)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", "UserId 1"));
+                        .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -159,7 +159,7 @@ public class UserCommandApiTest extends ApiTest {
     void 사용자_사진을_삭제한다() throws Exception {
         // given & when
         final ResultActions resultActions = mockMvc.perform(delete("/profile/image")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
+++ b/src/test/java/daybyquest/user/presentation/UserCommandApiTest.java
@@ -135,9 +135,7 @@ public class UserCommandApiTest extends ApiTest {
     @Test
     void 사용자_사진을_수정한다() throws Exception {
         // given
-        final MockMultipartFile file =
-                new MockMultipartFile("image", "image.png",
-                        "multipart/form-data", "file content".getBytes());
+        final MockMultipartFile file = 사진을_전송한다("image");
 
         // when
         final ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/daybyquest/user/presentation/UserQueryApiTest.java
+++ b/src/test/java/daybyquest/user/presentation/UserQueryApiTest.java
@@ -51,7 +51,7 @@ public class UserQueryApiTest extends ApiTest {
 
         // when
         final ResultActions resultActions = mockMvc.perform(get("/profile/{username}", ALICE.username)
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -67,7 +67,7 @@ public class UserQueryApiTest extends ApiTest {
 
         // when
         final ResultActions resultActions = mockMvc.perform(get("/profile")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -92,7 +92,7 @@ public class UserQueryApiTest extends ApiTest {
     void 계정_공개_범위를_조회한다() throws Exception {
         // given & when
         final ResultActions resultActions = mockMvc.perform(get("/profile/visibility")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())
@@ -114,7 +114,7 @@ public class UserQueryApiTest extends ApiTest {
                 .param("keyword", "dlwlrma")
                 .param("limit", "5")
                 .param("lastId", "0")
-                .header("Authorization", "UserId 1"));
+                .header(인증_헤더_이름, 사용자_인증_헤더));
 
         // then
         resultActions.andExpect(status().isOk())


### PR DESCRIPTION
## 🗒️ Summary
- 테스트 시 인증 관련 헤더의 키와 값을 상수화
- `MultipartForm` 요청의 경우 `MockMultipartFile`을 만드는 과정을 메서드로 추출

> resolve: #82

## 💡 More
- 