### PR TITLE
[Fix] 퀘스트 조회 시 링크된 게시물 수를 일관성 있도록 수정한다

### DIFF
--- a/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
+++ b/src/main/java/daybyquest/quest/query/QuestDaoQuerydslImpl.java
@@ -2,8 +2,6 @@ package daybyquest.quest.query;
 
 import static daybyquest.group.domain.QGroup.group;
 import static daybyquest.participant.domain.QParticipant.participant;
-import static daybyquest.post.domain.PostState.SUCCESS;
-import static daybyquest.post.domain.QPost.post;
 import static daybyquest.quest.domain.QQuest.quest;
 import static daybyquest.quest.domain.QuestState.ACTIVE;
 
@@ -57,9 +55,9 @@ public class QuestDaoQuerydslImpl implements QuestDao {
                 quest.expiredAt,
                 quest.image,
                 quest.rewardCount,
-                JPAExpressions.select(post.count())
-                        .from(post)
-                        .where(post.userId.eq(userId), post.questId.eq(id), post.state.eq(SUCCESS)),
+                JPAExpressions.select(participant.linkedCount)
+                        .from(participant)
+                        .where(participant.userId.eq(userId), participant.quest.id.eq(id)),
                 group.name
         );
     }

--- a/src/main/java/daybyquest/quest/query/QuestData.java
+++ b/src/main/java/daybyquest/quest/query/QuestData.java
@@ -4,6 +4,7 @@ import daybyquest.image.domain.Image;
 import daybyquest.participant.domain.ParticipantState;
 import daybyquest.quest.domain.QuestCategory;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Getter;
 
 @Getter
@@ -49,13 +50,9 @@ public class QuestData {
         this.expiredAt = expiredAt;
         this.image = image;
         this.rewardCount = rewardCount;
-        this.currentCount = currentCount;
+        this.currentCount = Objects.requireNonNullElse(currentCount, 0L);
         this.groupName = groupName;
-        if (state == null) {
-            this.state = ParticipantState.NOT;
-            return;
-        }
-        this.state = state;
+        this.state = Objects.requireNonNullElse(state, ParticipantState.NOT);
     }
 
     public String getImageIdentifier() {

--- a/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
+++ b/src/test/java/daybyquest/quest/query/QuestDaoQuerydslImplTest.java
@@ -19,6 +19,7 @@ import static daybyquest.support.fixture.UserFixtures.ALICE;
 import static daybyquest.support.fixture.UserFixtures.BOB;
 import static daybyquest.support.fixture.UserFixtures.CHARLIE;
 import static daybyquest.support.fixture.UserFixtures.DAVID;
+import static daybyquest.support.util.ParticipantUtils.게시물_연결_횟수를_지정한다;
 import static daybyquest.support.util.ParticipantUtils.퀘스트를_계속한다;
 import static daybyquest.support.util.ParticipantUtils.퀘스트를_끝낸다;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -127,9 +128,12 @@ public class QuestDaoQuerydslImplTest extends QuerydslTest {
         // given
         final User user = 저장한다(ALICE.생성());
         final Quest quest = 저장한다(QUEST_1.일반_퀘스트_생성());
+        QUEST_1.보상_없이_세부사항을_설정한다(quest);
+        final Participant participant = 저장한다(new Participant(user.getId(), quest));
         저장한다(POST_1.링크_성공_상태로_생성(user, quest));
         저장한다(POST_2.링크_성공_상태로_생성(user, quest));
         저장한다(POST_3.생성(user, quest));
+        게시물_연결_횟수를_지정한다(participant, 2L);
 
         // when
         final QuestData questData = questDao.getById(user.getId(), quest.getId());


### PR DESCRIPTION
## 🗒️ Summary
- 

> resolve: #149 

## 💡 More
- 