### PR TITLE
[Style] LocalDateTime와 관련된 응답의 가독성을 개선한다

### DIFF
--- a/src/main/java/daybyquest/badge/application/GetMyBadgesService.java
+++ b/src/main/java/daybyquest/badge/application/GetMyBadgesService.java
@@ -29,7 +29,7 @@ public class GetMyBadgesService {
 
     private LocalDateTime getLastTime(final List<BadgeData> badgeData) {
         if (badgeData.isEmpty()) {
-            return TimeConstant.MAX;
+            return TimeConstant.MIN;
         }
         return badgeData.get(badgeData.size() - 1).getAcquiredAt();
     }

--- a/src/main/java/daybyquest/badge/application/GetMyBadgesService.java
+++ b/src/main/java/daybyquest/badge/application/GetMyBadgesService.java
@@ -4,6 +4,7 @@ import daybyquest.badge.dto.response.BadgeResponse;
 import daybyquest.badge.dto.response.PageBadgesResponse;
 import daybyquest.badge.query.BadgeDao;
 import daybyquest.badge.query.BadgeData;
+import daybyquest.global.constant.TimeConstant;
 import daybyquest.global.query.NoOffsetTimePage;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +29,7 @@ public class GetMyBadgesService {
 
     private LocalDateTime getLastTime(final List<BadgeData> badgeData) {
         if (badgeData.isEmpty()) {
-            return LocalDateTime.MIN;
+            return TimeConstant.MAX;
         }
         return badgeData.get(badgeData.size() - 1).getAcquiredAt();
     }

--- a/src/main/java/daybyquest/global/constant/TimeConstant.java
+++ b/src/main/java/daybyquest/global/constant/TimeConstant.java
@@ -1,0 +1,13 @@
+package daybyquest.global.constant;
+
+import java.time.LocalDateTime;
+
+public final class TimeConstant {
+
+    public static final LocalDateTime MAX = LocalDateTime.of(9999, 12, 31, 0, 0);
+
+    public static final LocalDateTime EXAMPLE = LocalDateTime.of(2023, 12, 01, 0, 0);
+
+    private TimeConstant() {
+    }
+}

--- a/src/main/java/daybyquest/global/constant/TimeConstant.java
+++ b/src/main/java/daybyquest/global/constant/TimeConstant.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 public final class TimeConstant {
 
+    public static final LocalDateTime MIN = LocalDateTime.of(0, 1, 1, 0, 0);
+
     public static final LocalDateTime MAX = LocalDateTime.of(9999, 12, 31, 0, 0);
 
     public static final LocalDateTime EXAMPLE = LocalDateTime.of(2023, 12, 01, 0, 0);

--- a/src/test/java/daybyquest/badge/presentation/BadgeQueryApiTest.java
+++ b/src/test/java/daybyquest/badge/presentation/BadgeQueryApiTest.java
@@ -12,8 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import daybyquest.badge.application.GetMyBadgesService;
 import daybyquest.badge.dto.response.PageBadgesResponse;
+import daybyquest.global.constant.TimeConstant;
 import daybyquest.support.test.ApiTest;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,7 +30,7 @@ public class BadgeQueryApiTest extends ApiTest {
     void 내_뱃지_목록을_조회한다() throws Exception {
         // given
         given(getMyBadgesService.invoke(eq(로그인_ID), any())).willReturn(
-                new PageBadgesResponse(List.of(BADGE_1.응답(1L), BADGE_2.응답(2L)), LocalDateTime.MAX));
+                new PageBadgesResponse(List.of(BADGE_1.응답(1L), BADGE_2.응답(2L)), TimeConstant.EXAMPLE));
 
         // when
         final ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/daybyquest/support/fixture/BadgeFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/BadgeFixtures.java
@@ -2,8 +2,8 @@ package daybyquest.support.fixture;
 
 import daybyquest.badge.domain.Badge;
 import daybyquest.badge.dto.response.BadgeResponse;
+import daybyquest.global.constant.TimeConstant;
 import daybyquest.image.domain.Image;
-import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public enum BadgeFixtures {
@@ -37,6 +37,6 @@ public enum BadgeFixtures {
     }
 
     public BadgeResponse 응답(final Long id) {
-        return new BadgeResponse(name, imageIdentifier, id, LocalDateTime.MIN);
+        return new BadgeResponse(name, imageIdentifier, id, TimeConstant.EXAMPLE);
     }
 }

--- a/src/test/java/daybyquest/support/fixture/CommentFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/CommentFixtures.java
@@ -3,10 +3,10 @@ package daybyquest.support.fixture;
 import daybyquest.comment.domain.Comment;
 import daybyquest.comment.dto.response.CommentResponse;
 import daybyquest.comment.query.CommentData;
+import daybyquest.global.constant.TimeConstant;
 import daybyquest.post.domain.Post;
 import daybyquest.user.domain.User;
 import daybyquest.user.query.Profile;
-import java.time.LocalDateTime;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public enum CommentFixtures {
@@ -40,7 +40,7 @@ public enum CommentFixtures {
     }
 
     public CommentResponse 응답(final Long id, final Profile profile) {
-        final CommentData commentData = new CommentData(profile.getId(), id, content, LocalDateTime.MIN);
+        final CommentData commentData = new CommentData(profile.getId(), id, content, TimeConstant.EXAMPLE);
         return CommentResponse.of(commentData, profile);
     }
 }

--- a/src/test/java/daybyquest/support/fixture/PostFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/PostFixtures.java
@@ -3,6 +3,7 @@ package daybyquest.support.fixture;
 
 import static daybyquest.post.domain.PostState.SUCCESS;
 
+import daybyquest.global.constant.TimeConstant;
 import daybyquest.image.domain.Image;
 import daybyquest.post.domain.Post;
 import daybyquest.post.dto.response.PostResponse;
@@ -11,7 +12,6 @@ import daybyquest.post.query.PostData;
 import daybyquest.quest.domain.Quest;
 import daybyquest.user.domain.User;
 import daybyquest.user.query.Profile;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -65,14 +65,14 @@ public enum PostFixtures {
     }
 
     public PostResponse 응답(final Long id, final Profile profile) {
-        final PostData postData = new PostData(profile.getId(), id, content, LocalDateTime.MIN, false,
+        final PostData postData = new PostData(profile.getId(), id, content, TimeConstant.EXAMPLE, false,
                 null, null, SUCCESS);
         postData.setImages(사진_목록());
         return PostResponse.of(postData, profile);
     }
 
     public PostWithQuestResponse 퀘스트와_함께_응답(final Long id, final Profile profile) {
-        final PostData postData = new PostData(profile.getId(), id, content, LocalDateTime.MIN, false,
+        final PostData postData = new PostData(profile.getId(), id, content, TimeConstant.EXAMPLE, false,
                 null, null, SUCCESS);
         postData.setImages(사진_목록());
         return PostWithQuestResponse.of(postData, profile);


### PR DESCRIPTION
## 🗒️ Summary
- API 테스트시 응답의 LocalDateTime의 범위를 정상적인 형태로 변경
- `lastTime` 응답 시 `MIN` 값으로 `00년 1월 1일`을 응답

>

## 💡 More
- 