### PR TITLE
[Fix] 게시물 판정 시 링크된 퀘스트가 일반 퀘스트라면 실패 판정을 바로 적용한다

### DIFF
--- a/src/main/java/daybyquest/post/application/JudgePostService.java
+++ b/src/main/java/daybyquest/post/application/JudgePostService.java
@@ -5,6 +5,7 @@ import daybyquest.post.domain.Post;
 import daybyquest.post.domain.Posts;
 import daybyquest.post.domain.SuccessfullyPostLinkedEvent;
 import daybyquest.post.dto.request.JudgePostRequest;
+import daybyquest.quest.domain.Quests;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,10 +15,14 @@ public class JudgePostService {
 
     private final Posts posts;
 
+    private final Quests quests;
+
     private final ApplicationEventPublisher publisher;
 
-    public JudgePostService(final Posts posts, final ApplicationEventPublisher publisher) {
+    public JudgePostService(final Posts posts, final Quests quests,
+            final ApplicationEventPublisher publisher) {
         this.posts = posts;
+        this.quests = quests;
         this.publisher = publisher;
     }
 
@@ -30,6 +35,11 @@ public class JudgePostService {
             publisher.publishEvent(new SuccessfullyPostLinkedEvent(post.getUserId(), post.getQuestId()));
             return;
         }
-        post.needCheck();
+        
+        if (quests.getById(post.getQuestId()).isGroupQuest()) {
+            post.needCheck();
+            return;
+        }
+        post.fail();
     }
 }

--- a/src/main/java/daybyquest/post/domain/Post.java
+++ b/src/main/java/daybyquest/post/domain/Post.java
@@ -121,7 +121,7 @@ public class Post {
 
     public void fail() {
         validateQuestLink();
-        if (state != NEED_CHECK) {
+        if (state != NOT_DECIDED && state != NEED_CHECK) {
             throw new InvalidDomainException(ALREADY_JUDGED_POST);
         }
         state = FAIL;

--- a/src/test/java/daybyquest/post/domain/PostTest.java
+++ b/src/test/java/daybyquest/post/domain/PostTest.java
@@ -138,7 +138,6 @@ public class PostTest {
     void 퀘스트_링크를_실패_처리_한다() {
         // given
         final Post post = POST_1.생성(1L, 2L);
-        post.needCheck();
 
         // when
         post.fail();
@@ -148,9 +147,10 @@ public class PostTest {
     }
 
     @Test
-    void 퀘스트_링크_실패_처리_시_확인_필요_상태가_아니라면_예외를_던진다() {
+    void 퀘스트_링크_실패_처리_시_미처리나_확인_필요_상태가_아니라면_예외를_던진다() {
         // given
         final Post post = POST_1.생성(1L, 2L);
+        post.success();
 
         // when & then
         assertThatThrownBy(post::fail)


### PR DESCRIPTION
## 🗒️ Summary
- 

> resolve: #156 

## 💡 More
- 