### PR TITLE
[Test] 응용 계층 테스트 기반 코드를 작성한다

### DIFF
--- a/src/main/java/daybyquest/user/application/UpdateUserInterestService.java
+++ b/src/main/java/daybyquest/user/application/UpdateUserInterestService.java
@@ -4,7 +4,6 @@ import daybyquest.interest.domain.Interests;
 import daybyquest.user.domain.User;
 import daybyquest.user.domain.Users;
 import daybyquest.user.dto.request.UpdateUserInterestRequest;
-import java.util.Collection;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +23,7 @@ public class UpdateUserInterestService {
     @Transactional
     public void invoke(final Long loginId, final UpdateUserInterestRequest request) {
         final User user = users.getById(loginId);
-        final Collection<String> interests = request.getInterests();
-        this.interests.validateInterests(interests);
-        user.updateInterests(interests);
+        interests.validateInterests(request.getInterests());
+        user.updateInterests(request.getInterests());
     }
 }

--- a/src/test/java/daybyquest/DbqApplicationTests.java
+++ b/src/test/java/daybyquest/DbqApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DbqApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/daybyquest/support/config/StubImageIdentifierGenerator.java
+++ b/src/test/java/daybyquest/support/config/StubImageIdentifierGenerator.java
@@ -1,0 +1,11 @@
+package daybyquest.support.config;
+
+import daybyquest.image.domain.ImageIdentifierGenerator;
+
+public class StubImageIdentifierGenerator implements ImageIdentifierGenerator {
+
+    @Override
+    public String generate(final String category, final String originalName) {
+        return originalName;
+    }
+}

--- a/src/test/java/daybyquest/support/config/StubImages.java
+++ b/src/test/java/daybyquest/support/config/StubImages.java
@@ -1,0 +1,33 @@
+package daybyquest.support.config;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.image.domain.Images;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+public class StubImages implements Images {
+
+    private final Set<String> identifiers;
+
+    public StubImages() {
+        this.identifiers = new HashSet<>();
+    }
+
+    @Override
+    public void upload(final String identifier, final InputStream imageStream) {
+        identifiers.add(identifier);
+    }
+
+    @Override
+    public void remove(final String identifier) {
+        if (!identifiers.contains(identifier)) {
+            throw new InvalidDomainException();
+        }
+        identifiers.remove(identifier);
+    }
+
+    public boolean hasUploadImage(final String identifier) {
+        return identifiers.contains(identifier);
+    }
+}

--- a/src/test/java/daybyquest/support/config/StubInfraConfig.java
+++ b/src/test/java/daybyquest/support/config/StubInfraConfig.java
@@ -1,0 +1,21 @@
+package daybyquest.support.config;
+
+import daybyquest.image.domain.ImageIdentifierGenerator;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class StubInfraConfig {
+
+    @Bean
+    public StubImages images() {
+        return new StubImages();
+    }
+
+    @Bean
+    @Primary
+    public ImageIdentifierGenerator imageIdentifierGenerator() {
+        return new StubImageIdentifierGenerator();
+    }
+}

--- a/src/test/java/daybyquest/support/fixture/UserFixtures.java
+++ b/src/test/java/daybyquest/support/fixture/UserFixtures.java
@@ -11,7 +11,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 public enum UserFixtures {
 
-    ALICE("alice", "alice@email.com", "alice", "alice.png"),
+    ALICE("alice", "alice@email.com", "alice", "base.png"),
     BOB("bob", "bob@email.com", "bob", "bob.png"),
     CHARLIE("charlie", "charlie@email.com", "charlie", "charlie.png"),
     DAVID("david", "david@email.com", "david", "david.png");

--- a/src/test/java/daybyquest/support/test/ServiceTest.java
+++ b/src/test/java/daybyquest/support/test/ServiceTest.java
@@ -1,0 +1,42 @@
+package daybyquest.support.test;
+
+import static daybyquest.support.fixture.UserFixtures.ALICE;
+import static daybyquest.support.fixture.UserFixtures.BOB;
+
+import daybyquest.support.config.StubInfraConfig;
+import daybyquest.support.util.DatabaseCleaner;
+import daybyquest.user.domain.Users;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@SpringBootTest(classes = {StubInfraConfig.class})
+public class ServiceTest {
+
+    @Autowired
+    private DatabaseCleaner cleaner;
+
+    @Autowired
+    protected Users users;
+
+    @AfterEach
+    void cleanDatabase() {
+        cleaner.clean();
+    }
+
+    protected Long ALICE를_저장한다() {
+        return users.save(ALICE.생성()).getId();
+    }
+
+    protected Long BOB을_저장한다() {
+        return users.save(BOB.생성()).getId();
+    }
+
+    protected MultipartFile 사진_파일() {
+        return new MockMultipartFile("image", "image.png",
+                MediaType.MULTIPART_FORM_DATA_VALUE, "file content".getBytes());
+    }
+}

--- a/src/test/java/daybyquest/support/util/DatabaseCleaner.java
+++ b/src/test/java/daybyquest/support/util/DatabaseCleaner.java
@@ -1,0 +1,43 @@
+package daybyquest.support.util;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @PostConstruct
+    public void setUp() {
+        this.tableNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(e -> e.getJavaType().getDeclaredAnnotation(Entity.class) != null)
+                .map(e -> convertToSnakeCase(e.getName()))
+                .collect(Collectors.toList());
+    }
+
+    private String convertToSnakeCase(final String original) {
+        return original.replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
+                .replaceAll("([a-z])([A-Z])", "$1_$2")
+                .toLowerCase();
+    }
+
+    @Transactional
+    public void clean() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET foreign_key_checks = 0").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE `" + tableName + "`").executeUpdate();
+        }
+        entityManager.createNativeQuery("SET foreign_key_checks = 1").executeUpdate();
+    }
+}

--- a/src/test/java/daybyquest/user/application/SaveUserServiceTest.java
+++ b/src/test/java/daybyquest/user/application/SaveUserServiceTest.java
@@ -1,0 +1,64 @@
+package daybyquest.user.application;
+
+import static daybyquest.support.fixture.UserFixtures.ALICE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.profile.domain.ProfileSetting;
+import daybyquest.profile.domain.ProfileSettings;
+import daybyquest.support.test.ServiceTest;
+import daybyquest.user.domain.User;
+import daybyquest.user.dto.request.SaveUserRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SaveUserServiceTest extends ServiceTest {
+
+    @Autowired
+    private SaveUserService saveUserService;
+
+    @Autowired
+    private ProfileSettings profileSettings;
+
+    @Test
+    void 사용자를_저장한다() {
+        // given
+        final SaveUserRequest request = 회원가입_요청(ALICE.생성());
+
+        // when
+        final Long id = saveUserService.invoke(request);
+
+        // then
+        final User user = users.getById(id);
+        final ProfileSetting profileSetting = profileSettings.getById(id);
+        assertAll(() -> {
+            assertThat(user.getId()).isEqualTo(id);
+            assertThat(user.getUsername()).isEqualTo(ALICE.username);
+            assertThat(user.getName()).isEqualTo(ALICE.name);
+            assertThat(user.getEmail()).isEqualTo(ALICE.email);
+            assertThat(profileSetting.getUserId()).isEqualTo(id);
+        });
+    }
+
+    @Test
+    void 사용자_이름이_중복이면_예외를_던진다() {
+        // given
+        ALICE를_저장한다();
+        final SaveUserRequest request = 회원가입_요청(ALICE.생성());
+
+        // when & then
+        assertThatThrownBy(() -> saveUserService.invoke(request))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    private SaveUserRequest 회원가입_요청(final User user) {
+        final SaveUserRequest request = new SaveUserRequest();
+        ReflectionTestUtils.setField(request, "username", user.getUsername());
+        ReflectionTestUtils.setField(request, "email", user.getEmail());
+        ReflectionTestUtils.setField(request, "name", user.getName());
+        return request;
+    }
+}

--- a/src/test/java/daybyquest/user/application/UpdateUserImageServiceTest.java
+++ b/src/test/java/daybyquest/user/application/UpdateUserImageServiceTest.java
@@ -1,0 +1,37 @@
+package daybyquest.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import daybyquest.support.config.StubImages;
+import daybyquest.support.test.ServiceTest;
+import daybyquest.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+public class UpdateUserImageServiceTest extends ServiceTest {
+
+    @Autowired
+    private UpdateUserImageService updateUserImageService;
+
+    @Autowired
+    private StubImages images;
+
+    @Test
+    void 사용자_사진을_수정한다() {
+        // given
+        final Long id = ALICE를_저장한다();
+        final MultipartFile file = 사진_파일();
+
+        // when
+        updateUserImageService.invoke(id, file);
+
+        // then
+        final User user = users.getById(id);
+        assertAll(() -> {
+            assertThat(user.getImageIdentifier()).isEqualTo(file.getOriginalFilename());
+            assertThat(images.hasUploadImage(file.getOriginalFilename())).isTrue();
+        });
+    }
+}

--- a/src/test/java/daybyquest/user/application/UpdateUserServiceTest.java
+++ b/src/test/java/daybyquest/user/application/UpdateUserServiceTest.java
@@ -1,0 +1,59 @@
+package daybyquest.user.application;
+
+import static daybyquest.support.fixture.UserFixtures.ALICE;
+import static daybyquest.support.fixture.UserFixtures.BOB;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import daybyquest.global.error.exception.InvalidDomainException;
+import daybyquest.support.test.ServiceTest;
+import daybyquest.user.domain.User;
+import daybyquest.user.dto.request.UpdateUserRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class UpdateUserServiceTest extends ServiceTest {
+
+    @Autowired
+    private UpdateUserService updateUserService;
+
+    @Test
+    void 사용자를_수정한다() {
+        // given
+        final Long id = ALICE를_저장한다();
+        final UpdateUserRequest request = 사용자_수정_요청(BOB.생성());
+
+        // when
+        updateUserService.invoke(id, request);
+
+        // then
+        final User user = users.getById(id);
+        assertAll(() -> {
+            assertThat(user.getId()).isEqualTo(id);
+            assertThat(user.getUsername()).isEqualTo(BOB.username);
+            assertThat(user.getName()).isEqualTo(BOB.name);
+            assertThat(user.getEmail()).isEqualTo(ALICE.email);
+        });
+    }
+
+    @Test
+    void 사용자_이름이_중복이면_예외를_던진다() {
+        // given
+        ALICE를_저장한다();
+        final Long id = BOB을_저장한다();
+        final UpdateUserRequest request = 사용자_수정_요청(ALICE.생성());
+
+        // when & then
+        assertThatThrownBy(() -> updateUserService.invoke(id, request))
+                .isInstanceOf(InvalidDomainException.class);
+    }
+
+    private UpdateUserRequest 사용자_수정_요청(final User user) {
+        final UpdateUserRequest request = new UpdateUserRequest();
+        ReflectionTestUtils.setField(request, "username", user.getUsername());
+        ReflectionTestUtils.setField(request, "name", user.getName());
+        return request;
+    }
+}


### PR DESCRIPTION
## 🗒️ Summary
- 응용 계층은 `@SpringBootTest`를 통한 통합 테스트로 작성하기로 결정
  - 비지니스의 가장 작은 단위이고, 도메인간 상호작용이 빈번하게 일어나므로 통합 테스트를 통해 검증하고자 했음.
- 테스트 간 격리를 위해 `DatabaseCleaner` 작성 
- 외부의 의존성을 담당하는 객체의 `Stub`을 만들어 주입
- 작성한 테스트 기반 객체들을 확인하기 위해 사용자 저장, 변경, 프로필 사진 변경 서비스만 테스트 작성

> #155

## 💡 More
- 응용 계층 테스트 시 어느범위의 예외까지 검증해야할 지는 고민 중..